### PR TITLE
Add decoupled state representation for extended poses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ list(
 
     src/imu/IMUIncrement.cpp
     src/imu/IMUHelper.cpp
+    src/imu/IMUPreintegrationHelper.cpp
 
     src/utils/Utils.cpp
     src/utils/CostFunctionUtils.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ list(
 
     src/local_parameterizations/PoseLocalParameterization.cpp
     src/local_parameterizations/ExtendedPoseLocalParameterization.cpp
+    src/local_parameterizations/SE23LocalParameterization.cpp
+    src/local_parameterizations/DecoupledExtendedPoseLocalParameterization.cpp
 
     src/lib/Covariance.cpp
     src/lib/FactorGraph.cpp

--- a/README.md
+++ b/README.md
@@ -48,19 +48,45 @@ ctest
 ```
 
 ## Example Usage
-This repo contains a simulated GPS/IMU fusion example and can be executed using
-the Python script:
+An simulated example of running batch estimators and sliding window filters for GPS/IMU fusion is provided in `gps_imu_example.cpp`. In this example, the state to be estimated is the IMU state, consisting of
+- Orientation, $\mathbf{C}_{ab} \in SO(3)$,
+- Inertial velocity, $\mathbf{v}_a \in \mathbb{R}^3$
+- Inertial position, $\mathbf{r}_a \in \mathbb{R}^3$,
+- IMU biases $\mathbf{b}_b \in \mathbb{R}^6$.
+
+This example showcases how this library can be utilized to test various state representations for estimation problems. For example, the orientation, velocity, and position can be parameterized as an element of $SE_2(3)$ as
+
+
+<p>
+$$
+\mathbf{T}_{ab} = 
+\left[\begin{array}{ccc}
+\mathbf{C}_{ab} & \mathbf{v}_a^{zw} & \mathbf{r}_a^{zw} \\
+\mathbf{0} & 1 & 0 \\
+\mathbf{0} & 0 & 1
+\end{array}\right] \in SE_2(3),
+$$
+</p>
+
+where either a "left" or "right" perturbation scheme can be used. Additionally, a user can select a more traditional state representation, $SO(3) \times \mathbb{R}^3 \times \mathbb{R}^3$, where a multiplicative error is used for the orientation and additive errors are used for the velocity and position. 
+
+To see how to run estimators using these various configurations, see the script `examples/python/run_gps_imu_fusion.py`, which can be run as
 ```bash
-$ python3 examples/python/run_gps_imu_fusion.py
+$ python3 examples/python/run_gps_imu_fusion.py \ 
+  --lie_direction "left" \
+  --state_representation "decoupled"
 ```
-The examples additionally depend on the [navlie](https://github.com/decargroup/navlie) Python library, used to generate simulated IMU and GPS measurements, and additionally evaluate the results of the optimization. To install `navlie`, run
+which can be run for both left and right Lie directions or and both $SE_2(3)$ and decoupled state representations.
+
+This additionally depends on the [navlie](https://github.com/decargroup/navlie) Python library, used to generate simulated IMU and GPS measurements, and additionally evaluate the results of the optimization. To install `navlie`, run
 ```
 $ git clone https://github.com/decargroup/navlie
 $ cd navlie
 $ pip install -e .
 ```
 
-The
+In this example, the state to be estimated is the IMU state, consisting of orientation $\mathbf{C}_{ab} \in SO(3)$, velocity $\mathbf{v}_a$, position $\mathbf{r}_a, gyroscope bias, and accelerometer bias. This example showcases how the library allows for easily changing the state representation. For example, the user can either represent the state as an element of 
+
 ## Acknowledgements
 This repo is inspired partially by [libRSF](https://github.com/TUC-ProAut/libRSF), another great library for robust estimation using Ceres. `libRSF` only supports autodiff cost functions, while this repo supports traditional Ceres cost functions with analytic differentiation and provides tools to additionally check Jacobians numerically. The use of analytical derivatives becomes important when implementing sliding window filters for specific problems, such as visual-inertial odometry where the evaluation point of the Jacobians must be artificially modified to ensure consistency. 
 

--- a/examples/gps_imu_example.cpp
+++ b/examples/gps_imu_example.cpp
@@ -150,14 +150,14 @@ void runSlidingWindowEstimator(
       // Overwrite the current IMU state with the latest one
       cur_imu_state = latest_imu_state;
 
-      writeVectorToFile(est_imu_file, latest_imu_state.toVector());
+      ceres_nav::writeVectorToFile(est_imu_file, latest_imu_state.toVector());
       Eigen::Matrix<double, 15, 15> imu_cov =
           factor_graph_utils::computeIMUCovariance(
               graph, latest_imu_state.timestamp(), keys);
       Eigen::Matrix<double, 226, 1> flat_cov;
       flat_cov(0) = latest_imu_state.timestamp();
-      flat_cov.block<225, 1>(1, 0) = flattenMatrix(imu_cov);
-      writeVectorToFile(cov_file, flat_cov);
+      flat_cov.block<225, 1>(1, 0) = ceres_nav::flattenMatrix(imu_cov);
+      ceres_nav::writeVectorToFile(cov_file, flat_cov);
     }
 
     prev_gps_timestamp = cur_gps_timestamp;
@@ -244,15 +244,15 @@ void runFullBatchEstimator(
   for (auto const &stamp : est_stamps) {
     IMUState cur_imu_state =
         factor_graph_utils::getIMUState(graph, stamp, keys);
-    writeVectorToFile(est_imu_file, cur_imu_state.toVector());
+    ceres_nav::writeVectorToFile(est_imu_file, cur_imu_state.toVector());
 
     Eigen::Matrix<double, 15, 15> imu_cov =
         factor_graph_utils::computeIMUCovariance(
             graph, cur_imu_state.timestamp(), keys);
     Eigen::Matrix<double, 226, 1> flat_cov;
     flat_cov(0) = cur_imu_state.timestamp();
-    flat_cov.block<225, 1>(1, 0) = flattenMatrix(imu_cov);
-    writeVectorToFile(cov_file, flat_cov);
+    flat_cov.block<225, 1>(1, 0) = ceres_nav::flattenMatrix(imu_cov);
+    ceres_nav::writeVectorToFile(cov_file, flat_cov);
   }
 }
 
@@ -333,8 +333,8 @@ int main(int argc, const char **argv) {
   std::string output_dir = args["output_dir"].as<std::string>();
   std::string est_imu_states_file = output_dir + "/optimized_imu_states.txt";
   std::string cov_file = output_dir + "/covariances.txt";
-  createNewFile(est_imu_states_file);
-  createNewFile(cov_file);
+  ceres_nav::createNewFile(est_imu_states_file);
+  ceres_nav::createNewFile(cov_file);
 
   IMUState init_imu_state = imu_states_gt[0];
   Eigen::Matrix<double, 15, 15> init_cov =

--- a/examples/include/FactorGraphUtils.h
+++ b/examples/include/FactorGraphUtils.h
@@ -26,12 +26,15 @@ struct ProblemKeys {
   std::string bias_state_key = "gyro_bias";
 };
 
-void addIMUState(ceres_nav::FactorGraph &graph, const IMUState &imu_state,
-                 const LieDirection direction,
-                 ProblemKeys keys = ProblemKeys()) {
+void addIMUState(
+    ceres_nav::FactorGraph &graph, const IMUState &imu_state,
+    const LieDirection direction,
+    ExtendedPoseRepresentation state_rep = ExtendedPoseRepresentation::SE23,
+    ProblemKeys keys = ProblemKeys()) {
   // Create a new ExtendedPoseParameterBlock for the IMU state
   std::shared_ptr<ExtendedPoseParameterBlock> nav_state_block =
-      std::make_shared<ExtendedPoseParameterBlock>(imu_state.navState());
+      std::make_shared<ExtendedPoseParameterBlock>(imu_state.navState(),
+                                                   state_rep);
   std::shared_ptr<ParameterBlock<6>> bias_block =
       std::make_shared<ParameterBlock<6>>(imu_state.bias());
 
@@ -42,7 +45,8 @@ void addIMUState(ceres_nav::FactorGraph &graph, const IMUState &imu_state,
 void addPriorFactor(ceres_nav::FactorGraph &graph,
                     const IMUState prior_imu_state,
                     const Eigen::Matrix<double, 15, 15> &prior_covariance,
-                    LieDirection direction, ProblemKeys keys) {
+                    LieDirection direction,
+                    ExtendedPoseRepresentation state_rep, ProblemKeys keys) {
   std::vector<ceres_nav::StateID> state_ids = {
       ceres_nav::StateID(keys.nav_state_key, prior_imu_state.timestamp()),
       ceres_nav::StateID(keys.bias_state_key, prior_imu_state.timestamp())};
@@ -56,31 +60,34 @@ void addPriorFactor(ceres_nav::FactorGraph &graph,
 void addPreintegrationFactor(ceres_nav::FactorGraph &graph,
                              const IMUIncrement &imu_increment,
                              LieDirection &direction,
+                             ExtendedPoseRepresentation state_rep,
                              ProblemKeys keys = ProblemKeys()) {
   double start_stamp = imu_increment.start_stamp;
   double end_stamp = imu_increment.end_stamp;
-  std::vector<ceres_nav::StateID> state_ids = {ceres_nav::StateID(keys.nav_state_key, start_stamp),
-                                    ceres_nav::StateID(keys.bias_state_key, start_stamp),
-                                    ceres_nav::StateID(keys.nav_state_key, end_stamp),
-                                    ceres_nav::StateID(keys.bias_state_key, end_stamp)};
+  std::vector<ceres_nav::StateID> state_ids = {
+      ceres_nav::StateID(keys.nav_state_key, start_stamp),
+      ceres_nav::StateID(keys.bias_state_key, start_stamp),
+      ceres_nav::StateID(keys.nav_state_key, end_stamp),
+      ceres_nav::StateID(keys.bias_state_key, end_stamp)};
 
-  auto *factor = new IMUPreintegrationFactor(imu_increment, false, direction);
+  auto *factor = new IMUPreintegrationFactor(imu_increment, false, direction, state_rep);
   graph.addFactor(state_ids, factor, start_stamp);
 }
 
 /**
  * @brief Adds a GPS factor to the graph
  */
-void addGPSFactor(ceres_nav::FactorGraph &graph, const GPSMessage &gps_message,
-                  const LieDirection &direction,
-                  const Eigen::Matrix3d &covariance,
-                  ProblemKeys keys = ProblemKeys()) {
+void addGPSFactor(
+    ceres_nav::FactorGraph &graph, const GPSMessage &gps_message,
+    const LieDirection &direction, const Eigen::Matrix3d &covariance,
+    ExtendedPoseRepresentation state_rep = ExtendedPoseRepresentation::SE23,
+    ProblemKeys keys = ProblemKeys()) {
   Eigen::Matrix3d sqrt_info = computeSquareRootInformation(covariance);
 
   std::vector<ceres_nav::StateID> state_ids = {
       ceres_nav::StateID(keys.nav_state_key, gps_message.timestamp)};
   auto factor =
-      new AbsolutePositionFactor(gps_message.measurement, direction, sqrt_info);
+      new AbsolutePositionFactor(gps_message.measurement, direction, sqrt_info, state_rep);
   graph.addFactor(state_ids, factor, gps_message.timestamp);
 }
 
@@ -131,7 +138,7 @@ void marginalizeIMUState(ceres_nav::FactorGraph &graph, double timestamp_marg,
   std::vector<ceres_nav::StateID> state_ids_marg = {
       ceres_nav::StateID(keys.nav_state_key, timestamp_marg),
       ceres_nav::StateID(keys.bias_state_key, timestamp_marg)};
-    
+
   graph.marginalizeStates(state_ids_marg);
 }
 

--- a/examples/include/FactorGraphUtils.h
+++ b/examples/include/FactorGraphUtils.h
@@ -34,7 +34,7 @@ void addIMUState(
   // Create a new ExtendedPoseParameterBlock for the IMU state
   std::shared_ptr<ExtendedPoseParameterBlock> nav_state_block =
       std::make_shared<ExtendedPoseParameterBlock>(imu_state.navState(),
-                                                   state_rep);
+                                                   state_rep, "extended_pose", direction);
   std::shared_ptr<ParameterBlock<6>> bias_block =
       std::make_shared<ParameterBlock<6>>(imu_state.bias());
 

--- a/examples/include/FactorGraphUtils.h
+++ b/examples/include/FactorGraphUtils.h
@@ -82,7 +82,7 @@ void addGPSFactor(
     const LieDirection &direction, const Eigen::Matrix3d &covariance,
     ExtendedPoseRepresentation state_rep = ExtendedPoseRepresentation::SE23,
     ProblemKeys keys = ProblemKeys()) {
-  Eigen::Matrix3d sqrt_info = computeSquareRootInformation(covariance);
+  Eigen::Matrix3d sqrt_info = ceres_nav::computeSquareRootInformation(covariance);
 
   std::vector<ceres_nav::StateID> state_ids = {
       ceres_nav::StateID(keys.nav_state_key, gps_message.timestamp)};

--- a/examples/python/run_gps_imu_fusion.py
+++ b/examples/python/run_gps_imu_fusion.py
@@ -36,7 +36,9 @@ class InertialNavigationExampleConfig:
     noise_active: bool = True
     gravity_mag = 9.80665
     lie_direction: str = "left"
-
+    # The state representation to use for the navigation state
+    # Options: "SE23" or "decoupled"
+    state_representation: str = "SE23"
     # Output direct and output file names
     output_dir: str = "unset_output_dir"
     gt_fname: str = "ground_truth.txt"

--- a/include/factors/AbsolutePositionFactor.h
+++ b/include/factors/AbsolutePositionFactor.h
@@ -4,14 +4,13 @@
 #include <ceres/ceres.h>
 #include <vector>
 
-#include "lie/LieDirection.h"
 #include "lib/ExtendedPoseParameterBlock.h"
+#include "lie/LieDirection.h"
 
 class AbsolutePositionFactor : public ceres::SizedCostFunction<3, 15> {
 public:
   Eigen::Vector3d meas;
   Eigen::Matrix3d sqrt_info;
-  bool print_debug = false;
 
   // Pose representation options
   ExtendedPoseRepresentation pose_type = ExtendedPoseRepresentation::SE23;
@@ -19,10 +18,10 @@ public:
 
   AbsolutePositionFactor(
       const Eigen::Vector3d &meas_, const LieDirection &direction_,
-      const Eigen::Matrix3d &sqrt_info_, bool print_debug_ = false,
+      const Eigen::Matrix3d &sqrt_info_,
       ExtendedPoseRepresentation pose_type_ = ExtendedPoseRepresentation::SE23)
       : meas{meas_}, direction{direction_}, sqrt_info{sqrt_info_},
-        print_debug{print_debug_}, pose_type{pose_type_} {}
+        pose_type{pose_type_} {}
 
   /**
    * @brief Residual and Jacobian computation

--- a/include/factors/AbsolutePositionFactor.h
+++ b/include/factors/AbsolutePositionFactor.h
@@ -5,33 +5,24 @@
 #include <vector>
 
 #include "lie/LieDirection.h"
+#include "lib/ExtendedPoseParameterBlock.h"
 
-class AbsolutePositionFactor : public ceres::CostFunction {
+class AbsolutePositionFactor : public ceres::SizedCostFunction<3, 15> {
 public:
-  LieDirection direction;
   Eigen::Vector3d meas;
   Eigen::Matrix3d sqrt_info;
   bool print_debug = false;
-  // Whether or not the input state is SE3 or SE23
-  std::string pose_type = "SE23";
 
-  AbsolutePositionFactor(const Eigen::Vector3d &meas_,
-                         const LieDirection &direction_,
-                         const Eigen::Matrix3d &sqrt_info_,
-                         const std::string &pose_type_ = "SE23",
-                         bool print_debug_ = false)
+  // Pose representation options
+  ExtendedPoseRepresentation pose_type = ExtendedPoseRepresentation::SE23;
+  LieDirection direction;
+
+  AbsolutePositionFactor(
+      const Eigen::Vector3d &meas_, const LieDirection &direction_,
+      const Eigen::Matrix3d &sqrt_info_, bool print_debug_ = false,
+      ExtendedPoseRepresentation pose_type_ = ExtendedPoseRepresentation::SE23)
       : meas{meas_}, direction{direction_}, sqrt_info{sqrt_info_},
-        print_debug{print_debug_}, pose_type{pose_type_} {
-    // Set the number of residuals and parameters
-    set_num_residuals(3);
-    if (pose_type == "SE3") {
-      mutable_parameter_block_sizes()->push_back(12);
-    } else if (pose_type == "SE23") {
-      mutable_parameter_block_sizes()->push_back(15);
-    } else {
-      throw std::runtime_error("Unknown pose type");
-    }
-  }
+        print_debug{print_debug_}, pose_type{pose_type_} {}
 
   /**
    * @brief Residual and Jacobian computation

--- a/include/factors/IMUPreintegrationFactor.h
+++ b/include/factors/IMUPreintegrationFactor.h
@@ -31,9 +31,10 @@ public:
    * Class constructor - each IMU factor needs an interoceptive measurement, a
    * time, and a continuous-time noise matrix.
    */
-  IMUPreintegrationFactor(IMUIncrement imu_increment_,
-                          bool use_group_jacobians_,
-                          const LieDirection &direction_);
+  IMUPreintegrationFactor(
+      IMUIncrement imu_increment_, bool use_group_jacobians_,
+      const LieDirection &direction_,
+      ExtendedPoseRepresentation pose_rep_ = ExtendedPoseRepresentation::SE23);
 
   IMUPreintegrationFactor() = delete;
   /**

--- a/include/factors/IMUPreintegrationFactor.h
+++ b/include/factors/IMUPreintegrationFactor.h
@@ -20,7 +20,11 @@ class IMUPreintegrationFactor
 public:
   IMUIncrement rmi;
   bool use_group_jacobians;
+
+  // Navigation state representation options
+  // This is used to determine how the Jacobians are computed
   LieDirection direction;
+  ExtendedPoseRepresentation pose_rep = ExtendedPoseRepresentation::SE23;
 
   /*
    * @brief Default constructor
@@ -51,9 +55,14 @@ public:
                       const IMUStateHolder &X_j) const;
 
   std::vector<Eigen::Matrix<double, 15, 15>>
-  computeRawJacobiansLeft(const IMUStateHolder &X_i, const IMUStateHolder &X_j) const;
+  computeRawJacobiansLeftSE23(const IMUStateHolder &X_i,
+                              const IMUStateHolder &X_j) const;
 
   std::vector<Eigen::Matrix<double, 15, 15>>
-  computeRawJacobiansRight(const IMUStateHolder &X_i,
-                           const IMUStateHolder &X_j) const;
+  computeRawJacobiansRightSE23(const IMUStateHolder &X_i,
+                               const IMUStateHolder &X_j) const;
+
+  std::vector<Eigen::Matrix<double, 15, 15>>
+  computeRawJacobiansRightDecoupled(const IMUStateHolder &X_i,
+                                    const IMUStateHolder &X_j) const;
 };

--- a/include/factors/IMUPreintegrationFactor.h
+++ b/include/factors/IMUPreintegrationFactor.h
@@ -5,26 +5,23 @@
 #include <vector>
 
 #include "imu/IMUIncrement.h"
-
-class IMUStateHolder {
-public:
-  Eigen::Matrix3d attitude;
-  Eigen::Vector3d velocity;
-  Eigen::Vector3d position;
-  Eigen::Vector3d bias_gyro;
-  Eigen::Vector3d bias_accel;
-};
+#include "imu/IMUPreintegrationHelper.h"
 
 class IMUPreintegrationFactor
     : public ceres::SizedCostFunction<15, 15, 6, 15, 6> {
 public:
-  IMUIncrement rmi;
-  bool use_group_jacobians;
+  // // The RMI
+  // IMUIncrement rmi;
 
-  // Navigation state representation options
-  // This is used to determine how the Jacobians are computed
-  LieDirection direction;
-  ExtendedPoseRepresentation pose_rep = ExtendedPoseRepresentation::SE23;
+  // // Navigation state representation options
+  // // This is used to determine how the Jacobians are computed
+  // LieDirection direction;
+  // ExtendedPoseRepresentation pose_rep = ExtendedPoseRepresentation::SE23;
+
+  // bool use_group_jacobians;
+
+  // Helper class to compute the residuals and Jacobians
+  IMUPreintegrationHelper helper;
 
   /*
    * @brief Default constructor
@@ -42,28 +39,4 @@ public:
    */
   virtual bool Evaluate(double const *const *parameters, double *residuals,
                         double **jacobians) const;
-
-  // Helper functions for error and Jacobian computation
-  Eigen::Matrix<double, 15, 1> computeRawError(const IMUStateHolder &X_i,
-                                               const IMUStateHolder &X_j) const;
-  Eigen::Matrix<double, 5, 5> getUpdatedRMI(const IMUStateHolder &X_i) const;
-  Eigen::Matrix<double, 5, 5> predictNavRMI(const IMUStateHolder &X_i,
-                                            const IMUStateHolder &X_j) const;
-
-  /** Functions to compute raw Jacobians of error function.*/
-  std::vector<Eigen::Matrix<double, 15, 15>>
-  computeRawJacobians(const IMUStateHolder &X_i,
-                      const IMUStateHolder &X_j) const;
-
-  std::vector<Eigen::Matrix<double, 15, 15>>
-  computeRawJacobiansLeftSE23(const IMUStateHolder &X_i,
-                              const IMUStateHolder &X_j) const;
-
-  std::vector<Eigen::Matrix<double, 15, 15>>
-  computeRawJacobiansRightSE23(const IMUStateHolder &X_i,
-                               const IMUStateHolder &X_j) const;
-
-  std::vector<Eigen::Matrix<double, 15, 15>>
-  computeRawJacobiansRightDecoupled(const IMUStateHolder &X_i,
-                                    const IMUStateHolder &X_j) const;
 };

--- a/include/factors/IMUPriorFactor.h
+++ b/include/factors/IMUPriorFactor.h
@@ -1,18 +1,21 @@
 #pragma once
 
+#include "lib/ExtendedPoseParameterBlock.h"
+#include "lie/LieDirection.h"
 #include <Eigen/Dense>
 #include <ceres/ceres.h>
-#include "lie/LieDirection.h"
 
 class IMUPriorFactor : public ceres::SizedCostFunction<15, 15, 6> {
 public:
   /**
    * @brief Construct the IMU prior factor
    */
-  IMUPriorFactor(const Eigen::Matrix<double, 5, 5> &prior_nav_state,
-                 const Eigen::Matrix<double, 6, 1> &prior_imu_bias,
-                 const Eigen::Matrix<double, 15, 15> &prior_covariance,
-                 LieDirection direction = LieDirection::left);
+  IMUPriorFactor(
+      const Eigen::Matrix<double, 5, 5> &prior_nav_state,
+      const Eigen::Matrix<double, 6, 1> &prior_imu_bias,
+      const Eigen::Matrix<double, 15, 15> &prior_covariance,
+      LieDirection direction = LieDirection::left,
+      ExtendedPoseRepresentation pose_rep = ExtendedPoseRepresentation::SE23);
 
   virtual ~IMUPriorFactor() {}
 
@@ -28,4 +31,5 @@ private:
   Eigen::Matrix<double, 15, 15> prior_covariance_;
   Eigen::Matrix<double, 15, 15> sqrt_info_;
   LieDirection direction_;
+  ExtendedPoseRepresentation pose_rep_;
 };

--- a/include/factors/MarginalizationPrior.h
+++ b/include/factors/MarginalizationPrior.h
@@ -40,7 +40,13 @@
 
 namespace ceres_nav {
 
-enum class ParameterType { ExtendedPose, Pose, Vector, Unknown };
+enum class ParameterType {
+  ExtendedPoseSE23,
+  ExtendedPoseDecoupled,
+  Pose,
+  Vector,
+  Unknown
+};
 
 ParameterType
 getLocalParamType(const ceres::LocalParameterization *local_param);

--- a/include/imu/IMUIncrement.h
+++ b/include/imu/IMUIncrement.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "lib/ExtendedPoseParameterBlock.h"
+#include "lie/LieDirection.h"
 #include <Eigen/Dense>
 #include <vector>
-#include "lie/LieDirection.h"
 
 class IMUIncrement {
 public:
@@ -14,7 +15,9 @@ public:
   Eigen::Matrix<double, 15, 15> covariance;
   Eigen::Matrix<double, 15, 15> jacobian;
 
+  // Navigation state representation options
   LieDirection direction;
+  ExtendedPoseRepresentation pose_rep = ExtendedPoseRepresentation::SE23;
 
   // Gravity vector
   Eigen::Vector3d gravity;
@@ -35,15 +38,14 @@ public:
   std::vector<Eigen::Vector3d> acc_buf;
   std::vector<Eigen::Vector3d> gyr_buf;
 
-  // Covariance propagation method
-  std::string covariance_prop_method;
-
   IMUIncrement(const Eigen::Matrix<double, 12, 12> Q_ct,
                Eigen::Vector3d init_gyro_bias, Eigen::Vector3d init_accel_bias,
                double init_stamp, const Eigen::Vector3d &gravity,
-               const std::string &covariance_prop_method, const LieDirection &direction);
+               const LieDirection &direction,
+               const ExtendedPoseRepresentation &pose_rep =
+                   ExtendedPoseRepresentation::SE23);
 
-  IMUIncrement(){};
+  // IMUIncrement(){};
 
   void reset(double new_start_stamp,
              const Eigen::Vector3d &new_gyro_bias = Eigen::Vector3d::Zero(),
@@ -57,13 +59,34 @@ public:
   void propagate(double dt, const Eigen::Vector3d &gyro,
                  const Eigen::Vector3d &acc);
 
-  void propagateCovarianceAndBiasJacContinuous(double dt, const Eigen::Vector3d &omega,
-                                               const Eigen::Vector3d &accel);
-
-  void symmetrize();
   Eigen::Matrix<double, 5, 5> getDeltaX();
 
   // Repropagate all relevant quantities from a new initial bias
   void repropagate(const Eigen::Vector3d &init_gyro_bias,
                    const Eigen::Vector3d &init_accel_bias);
+
+protected:
+  void symmetrize();
+
+  /**
+   * @brief Propagates forward the covariance and bias Jacobian.
+   */
+  void propagateCovarianceAndBiasJacobian(double dt,
+                                          const Eigen::Vector3d &omega,
+                                          const Eigen::Vector3d &accel);
+
+  // Helper functions to compute the continuous-time A and L matrices
+  void computeContinuousTimeJacobiansSE23(const Eigen::Matrix3d &C,
+                                          const Eigen::Vector3d &v,
+                                          const Eigen::Vector3d &r,
+                                          const Eigen::Vector3d &omega,
+                                          const Eigen::Vector3d &accel,
+                                          Eigen::Matrix<double, 15, 15> &A_ct,
+                                          Eigen::Matrix<double, 15, 12> &L_ct);
+
+  void computeContinuousTimeJacobiansDecoupled(
+      const Eigen::Matrix3d &C, const Eigen::Vector3d &v,
+      const Eigen::Vector3d &r, const Eigen::Vector3d &omega,
+      const Eigen::Vector3d &accel, Eigen::Matrix<double, 15, 15> &A_ct,
+      Eigen::Matrix<double, 15, 12> &L_ct);
 };

--- a/include/imu/IMUPreintegrationHelper.h
+++ b/include/imu/IMUPreintegrationHelper.h
@@ -68,6 +68,9 @@ public:
 
   // Gets the covariance of the preintegrated measurement
   Eigen::Matrix<double, 15, 15> covariance() const { return rmi.covariance; }
+  
+  double startStamp() const { return rmi.start_stamp; }
+  double endStamp() const { return rmi.end_stamp; }
 
 private:
   const IMUIncrement rmi;

--- a/include/imu/IMUPreintegrationHelper.h
+++ b/include/imu/IMUPreintegrationHelper.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <Eigen/Dense>
+#include <vector>
+
+#include "imu/IMUIncrement.h"
+
+/**
+ * @brief Simple struct to hold the IMU state components.
+ */
+struct IMUStateHolder {
+  Eigen::Matrix3d attitude;
+  Eigen::Vector3d velocity;
+  Eigen::Vector3d position;
+  Eigen::Vector3d bias_gyro;
+  Eigen::Vector3d bias_accel;
+
+  IMUStateHolder() = default;
+
+  IMUStateHolder(const Eigen::Matrix3d &att, const Eigen::Vector3d &vel,
+                 const Eigen::Vector3d &pos, const Eigen::Vector3d &bg,
+                 const Eigen::Vector3d &ba)
+      : attitude{att}, velocity{vel}, position{pos}, bias_gyro{bg}, bias_accel{
+                                                                        ba} {}
+};
+
+/**
+ * @brief Helper class to comptue IMU preintegration residuals and Jacobians.
+ *
+ * This class contains methods to compute everything required for the
+ * preintegration factor for various state representations and perturbation
+ * directions.
+ */
+class IMUPreintegrationHelper {
+public:
+  IMUPreintegrationHelper(const IMUIncrement &imu_increment,
+                          bool use_group_jacobians,
+                          const LieDirection &direction,
+                          ExtendedPoseRepresentation pose_rep);
+
+  // Main method to compute Jacobians based on representation and direction
+  std::vector<Eigen::Matrix<double, 15, 15>>
+  computeRawJacobians(const IMUStateHolder &X_i,
+                      const IMUStateHolder &X_j) const;
+
+  // SE23 Jacobian methods (both left and right)
+  std::vector<Eigen::Matrix<double, 15, 15>>
+  computeRawJacobiansLeftSE23(const IMUStateHolder &X_i,
+                              const IMUStateHolder &X_j) const;
+
+  std::vector<Eigen::Matrix<double, 15, 15>>
+  computeRawJacobiansRightSE23(const IMUStateHolder &X_i,
+                               const IMUStateHolder &X_j) const;
+
+  // Decoupled representation Jacobian methods
+  // TODO: Still need to implement Left Decoupled
+  std::vector<Eigen::Matrix<double, 15, 15>>
+  computeRawJacobiansRightDecoupled(const IMUStateHolder &X_i,
+                                    const IMUStateHolder &X_j) const;
+
+  // Methods to compute the RMI error
+  Eigen::Matrix<double, 5, 5> getUpdatedRMI(const IMUStateHolder &X_i) const;
+  Eigen::Matrix<double, 5, 5> predictNavRMI(const IMUStateHolder &X_i,
+                                            const IMUStateHolder &X_j) const;
+  Eigen::Matrix<double, 15, 1>
+  computePreintegrationError(const IMUStateHolder &X_i,
+                             const IMUStateHolder &X_j) const;
+
+  // Gets the covariance of the preintegrated measurement
+  Eigen::Matrix<double, 15, 15> covariance() const { return rmi.covariance; }
+
+private:
+  const IMUIncrement rmi;
+  bool use_group_jacobians;
+  LieDirection direction;
+  ExtendedPoseRepresentation pose_rep;
+};

--- a/include/lie/SO3.h
+++ b/include/lie/SO3.h
@@ -12,9 +12,9 @@ public:
   static Eigen::Matrix3d expMap(const Eigen::Vector3d &phi);
   static Eigen::Vector3d logMap(const Eigen::Matrix3d &element_so3);
   static Eigen::Matrix3d leftJacobian(const Eigen::Vector3d &phi);
-  static Eigen::Matrix3d computeJRight(const Eigen::Vector3d &phi);
-  static Eigen::Matrix3d leftJacobianInv(const Eigen::Vector3d &phi);
-  static Eigen::Matrix3d computeJRightInv(const Eigen::Vector3d &phi);
+  static Eigen::Matrix3d rightJacobian(const Eigen::Vector3d &phi);
+  static Eigen::Matrix3d leftJacobianInverse(const Eigen::Vector3d &phi);
+  static Eigen::Matrix3d rightJacobianInverse(const Eigen::Vector3d &phi);
   static Eigen::Matrix<double, 9, 1> flatten(const Eigen::Matrix3d C);
   static Eigen::Matrix3d unflatten(const Eigen::Matrix<double, 9, 1> vec_C);
   static Eigen::Vector3d toEuler(const Eigen::Matrix3d &C);

--- a/include/local_parameterizations/DecoupledExtendedPoseLocalParameterization.h
+++ b/include/local_parameterizations/DecoupledExtendedPoseLocalParameterization.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "ExtendedPoseLocalParameterization.h"  
+// #include <ceres/ceres.h>
+
+class DecoupledExtendedPoseLocalParameterization : public ExtendedPoseLocalParameterization {
+public:
+  using ExtendedPoseLocalParameterization::ExtendedPoseLocalParameterization;
+  ~DecoupledExtendedPoseLocalParameterization() override = default;
+  
+  /**
+   * @brief State update funciton for the extended Pose state.
+   */
+  bool Plus(const double *x, const double *delta, double *x_plus_delta) const;
+};

--- a/include/local_parameterizations/ExtendedPoseLocalParameterization.h
+++ b/include/local_parameterizations/ExtendedPoseLocalParameterization.h
@@ -15,32 +15,7 @@ public:
   /**
    * @brief State update funciton for the extended Pose state.
    */
-  bool Plus(const double *x, const double *delta, double *x_plus_delta) const;
-  /**
-   * @brief Computes the jacobian in respect to the local parameterization
-   *
-   * This essentially "tricks" ceres.
-   * Instead of doing what ceres wants:
-   * dr/dlocal= dr/dglobal * dglobal/dlocal
-   *
-   * We instead directly do:
-   * dr/dlocal= [ dr/dlocal, 0] * [I; 0]= dr/dlocal.
-   * Therefore we here define dglobal/dlocal= [I; 0]
-   *
-   * For example, lets consider orientation parameterized as a 4 DoF quaternion
-   * (denoted q). Consdier a residual, written e. In the cost function, the user
-   * supplies the Jacobian of the residual wrt the 4 DoF quaternion -> de / dq.
-   * Here, the user supplies the Jacobian of the quaternion w.r.t the Lie
-   * algebra element xi, -> dq / dxi Interally, Ceres then computes de / dxi =
-   * de / dq * dq / dxi. However, when we analytically derive Jacobians, it's
-   * often easiest to directly find de / dxi, the Jacobian of the residual w.r.t
-   * the Lie algebra. For this, a "trick" can be used where the user sets the
-   * ComputeJacobian method in the LocalParameteriation to identity, and
-   * supplies the Jacobian de / dxi directly in the CostFunction, wih zero
-   * columns in the correct places. For example, see
-   *      https://github.com/ceres-solver/ceres-solver/issues/387
-   *      https://github.com/ceres-solver/ceres-solver/issues/303
-   */
+  virtual bool Plus(const double *x, const double *delta, double *x_plus_delta) const = 0;
   bool ComputeJacobian(const double *x, double *jacobian) const;
   int GlobalSize() const { return 15; };
   int LocalSize() const { return 9; };

--- a/include/local_parameterizations/SE23LocalParameterization.h
+++ b/include/local_parameterizations/SE23LocalParameterization.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "ExtendedPoseLocalParameterization.h"
+#include <ceres/ceres.h>
+
+class SE23LocalParameterization : public ExtendedPoseLocalParameterization {
+public:
+
+  using ExtendedPoseLocalParameterization::ExtendedPoseLocalParameterization;
+  ~SE23LocalParameterization() override = default;
+  
+  /**
+   * @brief State update funciton for the extended Pose state.
+   */
+  bool Plus(const double *x, const double *delta, double *x_plus_delta) const;
+};

--- a/include/utils/Utils.h
+++ b/include/utils/Utils.h
@@ -6,6 +6,8 @@
 
 #include <ceres/ceres.h>
 
+namespace ceres_nav {
+
 double roundTo(double value, double precision);
 
 double roundStamp(double value);
@@ -45,3 +47,5 @@ void discretizeSystem(const Eigen::MatrixXd &A_ct, const Eigen::MatrixXd &L_ct,
                       const Eigen::MatrixXd &Q_ct, double dt,
                       Eigen::MatrixXd &A_d, Eigen::MatrixXd &Q_d,
                       DiscretizationMethod method = DiscretizationMethod::TaylorSeries);
+
+} // namespace ceres_nav

--- a/include/utils/Utils.h
+++ b/include/utils/Utils.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <Eigen/Dense>
 #include <iostream>
 #include <math.h>
-#include <Eigen/Dense>
 
 #include <ceres/ceres.h>
 
@@ -10,14 +10,13 @@ double roundTo(double value, double precision);
 
 double roundStamp(double value);
 
-Eigen::MatrixXd
-computeSquareRootInformation(const Eigen::MatrixXd &covariance);
-
+Eigen::MatrixXd computeSquareRootInformation(const Eigen::MatrixXd &covariance);
 
 /**
  * @brief Writes a vector as a single line to a file.
-*/
-void writeVectorToFile(const std::string &filename, const Eigen::VectorXd &vector);
+ */
+void writeVectorToFile(const std::string &filename,
+                       const Eigen::VectorXd &vector);
 
 /**
  * @brief Flattens a square matrix to a vector using row-major order.
@@ -32,3 +31,17 @@ Eigen::VectorXd flattenMatrix(const Eigen::MatrixXd &matrix);
  */
 void createNewFile(const std::string &filename);
 
+
+enum class DiscretizationMethod {
+    TaylorSeries,
+    FirstOrderHold,
+};
+
+/**
+ * @brief Discretizes a continuous-time linear system using the specified
+ * method.
+ */
+void discretizeSystem(const Eigen::MatrixXd &A_ct, const Eigen::MatrixXd &L_ct,
+                      const Eigen::MatrixXd &Q_ct, double dt,
+                      Eigen::MatrixXd &A_d, Eigen::MatrixXd &Q_d,
+                      DiscretizationMethod method = DiscretizationMethod::TaylorSeries);

--- a/src/factors/IMUPreintegrationFactor.cpp
+++ b/src/factors/IMUPreintegrationFactor.cpp
@@ -50,7 +50,7 @@ bool IMUPreintegrationFactor::Evaluate(double const *const *parameters,
   // covariance = 0.5 * (covariance + covariance.transpose());
 
   Eigen::Matrix<double, 15, 15> sqrt_info =
-      computeSquareRootInformation(covariance);
+      ceres_nav::computeSquareRootInformation(covariance);
 
   Eigen::Map<Eigen::Matrix<double, 15, 1>> residual(residuals);
   residual = error;

--- a/src/factors/IMUPreintegrationFactor.cpp
+++ b/src/factors/IMUPreintegrationFactor.cpp
@@ -5,7 +5,7 @@
 #include "lie/SO3.h"
 #include "utils/Utils.h"
 
-#include <iostream>
+#include <glog/logging.h>
 
 IMUPreintegrationFactor::IMUPreintegrationFactor(IMUIncrement imu_increment_,
                                                  bool use_group_jacobians_,
@@ -16,17 +16,15 @@ IMUPreintegrationFactor::IMUPreintegrationFactor(IMUIncrement imu_increment_,
 bool IMUPreintegrationFactor::Evaluate(double const *const *parameters,
                                        double *residuals,
                                        double **jacobians) const {
-  Eigen::Matrix3d C_i;
-  Eigen::Vector3d v_i;
-  Eigen::Vector3d r_i;
   Eigen::Matrix<double, 5, 5> T_i = SE23::fromCeresParameters(parameters[0]);
-  SE23::toComponents(T_i, C_i, v_i, r_i);
+  Eigen::Matrix3d C_i = T_i.block<3, 3>(0, 0);
+  Eigen::Vector3d v_i = T_i.block<3, 1>(0, 3);
+  Eigen::Vector3d r_i = T_i.block<3, 1>(0, 4);
 
-  Eigen::Matrix3d C_j;
-  Eigen::Vector3d v_j;
-  Eigen::Vector3d r_j;
   Eigen::Matrix<double, 5, 5> T_j = SE23::fromCeresParameters(parameters[2]);
-  SE23::toComponents(T_j, C_j, v_j, r_j);
+  Eigen::Matrix3d C_j = T_j.block<3, 3>(0, 0);
+  Eigen::Vector3d v_j = T_j.block<3, 1>(0, 3);
+  Eigen::Vector3d r_j = T_j.block<3, 1>(0, 4);
 
   Eigen::Vector3d bg_i(parameters[1][0], parameters[1][1], parameters[1][2]);
   Eigen::Vector3d ba_i(parameters[1][3], parameters[1][4], parameters[1][5]);
@@ -132,8 +130,19 @@ IMUPreintegrationFactor::computeRawError(const IMUStateHolder &X_i,
   // Get predicted RMI based on states and form the error
   Eigen::Matrix<double, 5, 5> Y_pred = predictNavRMI(X_i, X_j);
 
-  // Compute X^X \ominus X^Y
-  Eigen::Matrix<double, 9, 1> e_nav = SE23::minus(Y_pred, Y_meas, direction);
+  // Compute the error in the navigation state
+  Eigen::Matrix<double, 9, 1> e_nav = Eigen::Matrix<double, 9, 1>::Zero();
+  if (pose_rep == ExtendedPoseRepresentation::SE23) {
+    e_nav = SE23::minus(Y_pred, Y_meas, direction);
+  } else if (pose_rep == ExtendedPoseRepresentation::Decoupled) {
+    e_nav.block<3, 1>(0, 0) = SO3::minus(Y_pred.block<3, 3>(0, 0),
+                                         Y_meas.block<3, 3>(0, 0), direction);
+    e_nav.block<3, 1>(3, 0) =
+        Y_pred.block<3, 1>(0, 3) - Y_meas.block<3, 1>(0, 3);
+    e_nav.block<3, 1>(6, 0) =
+        Y_pred.block<3, 1>(0, 4) - Y_meas.block<3, 1>(0, 4);
+  }
+
   Eigen::Vector3d e_bg = X_j.bias_gyro - X_i.bias_gyro;
   Eigen::Vector3d e_ba = X_j.bias_accel - X_i.bias_accel;
 
@@ -155,13 +164,32 @@ IMUPreintegrationFactor::getUpdatedRMI(const IMUStateHolder &X_i) const {
   delta_X.block<3, 1>(0, 3) = rmi.delta_U.block<3, 1>(0, 3);
   delta_X.block<3, 1>(0, 4) = rmi.delta_U.block<3, 1>(0, 4);
 
-  if (direction == LieDirection::left) {
-    return SE23::expMap(rmi.bias_jacobian * dbias) * delta_X;
-  } else if (direction == LieDirection::right) {
-    return delta_X * SE23::expMap(rmi.bias_jacobian * dbias);
-  } else {
-    std::cout << "WARNING: Unknown Lie direction!" << std::endl;
-    return Eigen::Matrix<double, 5, 5>::Identity();
+  // If we're using an SE_2(3) representation, perform first-order
+  // bias correct directly on the group
+  if (pose_rep == ExtendedPoseRepresentation::SE23) {
+    if (direction == LieDirection::left) {
+      return SE23::expMap(rmi.bias_jacobian * dbias) * delta_X;
+    } else if (direction == LieDirection::right) {
+      return delta_X * SE23::expMap(rmi.bias_jacobian * dbias);
+    } else {
+      std::cout << "WARNING: Unknown Lie direction!" << std::endl;
+      return Eigen::Matrix<double, 5, 5>::Identity();
+    }
+  }
+
+  // Perform first-order bias correct for decoupled representation
+  else if (pose_rep == ExtendedPoseRepresentation::Decoupled) {
+    if (direction == LieDirection::left) {
+      LOG(INFO) << "Left Jacobians not implemented for decoupled navigation "
+                   "state representation.";
+    } else if (direction == LieDirection::right) {
+
+      // Update each component of delta_X matrix separately
+      // return delta_X * SO3::expMap(rmi.bias_jacobian.block<3, 6>(0, 0) * dbias);
+    } else {
+      LOG(INFO) << "Unknown Lie direction for decoupled navigation state "
+                   "representation.";
+    }
   }
 }
 
@@ -191,18 +219,30 @@ IMUPreintegrationFactor::predictNavRMI(const IMUStateHolder &X_i,
 std::vector<Eigen::Matrix<double, 15, 15>>
 IMUPreintegrationFactor::computeRawJacobians(const IMUStateHolder &X_i,
                                              const IMUStateHolder &X_j) const {
-  if (direction == LieDirection::left) {
-    return computeRawJacobiansLeft(X_i, X_j);
-  } else if (direction == LieDirection::right) {
-    return computeRawJacobiansRight(X_i, X_j);
-  } else {
-    std::cout << "WARNING: Unknown Lie direction!" << std::endl;
-    return std::vector<Eigen::Matrix<double, 15, 15>>();
+  if (pose_rep == ExtendedPoseRepresentation::SE23) {
+    if (direction == LieDirection::left) {
+      return computeRawJacobiansLeftSE23(X_i, X_j);
+    } else if (direction == LieDirection::right) {
+      return computeRawJacobiansRightSE23(X_i, X_j);
+    } else {
+      std::cout << "WARNING: Unknown Lie direction!" << std::endl;
+      return std::vector<Eigen::Matrix<double, 15, 15>>();
+    }
+  } else if (pose_rep == ExtendedPoseRepresentation::Decoupled) {
+    if (direction == LieDirection::left) {
+      LOG(INFO) << "Left Jacobians not implemented for decoupled navigation "
+                   "state representation.";
+    } else if (direction == LieDirection::right) {
+      return computeRawJacobiansRightDecoupled(X_i, X_j);
+    } else {
+      LOG(INFO) << "Unknown Lie direction for decoupled navigation state "
+                   "representation.";
+    }
   }
 }
 
 std::vector<Eigen::Matrix<double, 15, 15>>
-IMUPreintegrationFactor::computeRawJacobiansLeft(
+IMUPreintegrationFactor::computeRawJacobiansLeftSE23(
     const IMUStateHolder &X_i, const IMUStateHolder &X_j) const {
   // Extract individual states
   Eigen::Vector3d g_a = rmi.gravity;
@@ -290,7 +330,7 @@ IMUPreintegrationFactor::computeRawJacobiansLeft(
 }
 
 std::vector<Eigen::Matrix<double, 15, 15>>
-IMUPreintegrationFactor::computeRawJacobiansRight(
+IMUPreintegrationFactor::computeRawJacobiansRightSE23(
     const IMUStateHolder &X_i, const IMUStateHolder &X_j) const {
   Eigen::Matrix<double, 5, 5> del_Xx_mat = predictNavRMI(X_i, X_j);
 
@@ -340,6 +380,59 @@ IMUPreintegrationFactor::computeRawJacobiansRight(
   Eigen::Matrix<double, 15, 15> jac_i =
       De_D_delta_xy * xi_i_y + De_D_delta_xx * xi_i_x;
   jac_j = De_D_delta_xx * jac_j;
+
+  std::vector<Eigen::Matrix<double, 15, 15>> raw_jacobians;
+  raw_jacobians.push_back(jac_i);
+  raw_jacobians.push_back(jac_j);
+  return raw_jacobians;
+}
+
+std::vector<Eigen::Matrix<double, 15, 15>>
+IMUPreintegrationFactor::computeRawJacobiansRightDecoupled(
+    const IMUStateHolder &X_i, const IMUStateHolder &X_j) const {
+  Eigen::Matrix<double, 5, 5> del_Xx_mat = predictNavRMI(X_i, X_j);
+
+  // Extract required subcomponents of matrix
+  Eigen::Matrix3d del_Xx_C = del_Xx_mat.block<3, 3>(0, 0);
+  Eigen::Vector3d del_Xx_v = del_Xx_mat.block<3, 1>(0, 3);
+  Eigen::Vector3d del_Xx_r = del_Xx_mat.block<3, 1>(0, 4);
+  double delta_t = rmi.end_stamp - rmi.start_stamp;
+
+  Eigen::Matrix3d C_i = X_i.attitude;
+
+  // Compute Jacobian of \Delta_X^X with respect to X_i
+  Eigen::Matrix<double, 15, 15> xi_i_x = Eigen::Matrix<double, 15, 15>::Zero();
+  xi_i_x.block<3, 3>(0, 0) = -del_Xx_C.transpose();
+  xi_i_x.block<3, 3>(3, 0) = SO3::cross(del_Xx_v);
+  xi_i_x.block<3, 3>(3, 3) = -C_i.transpose();
+  xi_i_x.block<3, 3>(6, 0) = SO3::cross(del_Xx_r);
+  xi_i_x.block<3, 3>(6, 3) = -delta_t * C_i.transpose();
+  xi_i_x.block<3, 3>(6, 6) = -C_i.transpose();
+  xi_i_x.block<6, 6>(9, 9) = -Eigen::Matrix<double, 6, 6>::Identity();
+
+  // Compute Jacobian of error with respect to \Delta_X^Y
+  Eigen::Matrix<double, 15, 15> xi_i_y = Eigen::Matrix<double, 15, 15>::Zero();
+
+  // Compute Jacobian of \Delta X^X with respect to X_j
+  Eigen::Matrix<double, 15, 15> xi_j_x =
+      Eigen::Matrix<double, 15, 15>::Identity();
+  xi_j_x.block<3, 3>(3, 3) = C_i.transpose();
+  xi_j_x.block<3, 3>(6, 6) = C_i.transpose();
+
+  // Group Jacobians
+  Eigen::Matrix<double, 15, 15> De_D_delta_xy =
+      -Eigen::Matrix<double, 15, 15>::Identity();
+  Eigen::Matrix<double, 15, 15> De_D_delta_xx =
+      Eigen::Matrix<double, 15, 15>::Identity();
+
+  if (use_group_jacobians) {
+    LOG(INFO) << "Group Jacobians not implemented for decoupled navigation "
+                 "state representation.";
+  }
+
+  Eigen::Matrix<double, 15, 15> jac_i =
+      De_D_delta_xy * xi_i_y + De_D_delta_xx * xi_i_x;
+  Eigen::Matrix<double, 15, 15> jac_j = De_D_delta_xx * xi_j_x;
 
   std::vector<Eigen::Matrix<double, 15, 15>> raw_jacobians;
   raw_jacobians.push_back(jac_i);

--- a/src/factors/IMUPreintegrationFactor.cpp
+++ b/src/factors/IMUPreintegrationFactor.cpp
@@ -10,12 +10,12 @@
 IMUPreintegrationFactor::IMUPreintegrationFactor(
     IMUIncrement imu_increment_, bool use_group_jacobians_,
     const LieDirection &direction_, ExtendedPoseRepresentation pose_rep_)
-    : rmi{imu_increment_}, use_group_jacobians{use_group_jacobians_},
-      direction{direction_}, pose_rep{pose_rep_} {}
+    : helper{imu_increment_, use_group_jacobians_, direction_, pose_rep_} {}
 
 bool IMUPreintegrationFactor::Evaluate(double const *const *parameters,
                                        double *residuals,
                                        double **jacobians) const {
+  // Extract parameters
   Eigen::Matrix<double, 5, 5> T_i = SE23::fromCeresParameters(parameters[0]);
   Eigen::Matrix3d C_i = T_i.block<3, 3>(0, 0);
   Eigen::Vector3d v_i = T_i.block<3, 1>(0, 3);
@@ -25,32 +25,20 @@ bool IMUPreintegrationFactor::Evaluate(double const *const *parameters,
   Eigen::Matrix3d C_j = T_j.block<3, 3>(0, 0);
   Eigen::Vector3d v_j = T_j.block<3, 1>(0, 3);
   Eigen::Vector3d r_j = T_j.block<3, 1>(0, 4);
-
-  Eigen::Vector3d bg_i(parameters[1][0], parameters[1][1], parameters[1][2]);
-  Eigen::Vector3d ba_i(parameters[1][3], parameters[1][4], parameters[1][5]);
-
-  Eigen::Vector3d bg_j(parameters[3][0], parameters[3][1], parameters[3][2]);
-  Eigen::Vector3d ba_j(parameters[3][3], parameters[3][4], parameters[3][5]);
+  
+  Eigen::Map<const Eigen::Vector3d> bg_i(parameters[1]);
+  Eigen::Map<const Eigen::Vector3d> ba_i(parameters[1] + 3);
+  Eigen::Map<const Eigen::Vector3d> bg_j(parameters[3]);
+  Eigen::Map<const Eigen::Vector3d> ba_j(parameters[3] + 3);
 
   // Construct full IMU states
-  IMUStateHolder X_i;
-  X_i.attitude = C_i;
-  X_i.velocity = v_i;
-  X_i.position = r_i;
-  X_i.bias_gyro = bg_i;
-  X_i.bias_accel = ba_i;
-
-  IMUStateHolder X_j;
-  X_j.attitude = C_j;
-  X_j.velocity = v_j;
-  X_j.position = r_j;
-  X_j.bias_gyro = bg_j;
-  X_j.bias_accel = ba_j;
+  IMUStateHolder X_i(C_i, v_i, r_i, bg_i, ba_i);
+  IMUStateHolder X_j(C_j, v_j, r_j, bg_j, ba_j);
 
   // Compute error and weight
-  Eigen::Matrix<double, 15, 1> error = computeRawError(X_i, X_j);
-
-  Eigen::Matrix<double, 15, 15> covariance = rmi.covariance;
+  Eigen::Matrix<double, 15, 1> error =
+      helper.computePreintegrationError(X_i, X_j);
+  Eigen::Matrix<double, 15, 15> covariance = helper.covariance();
   // Eigen::Matrix<double, 15, 15> De_D_delta_xy =
   //     -Eigen::Matrix<double, 15, 15>::Identity();
   // if (use_group_jacobians) {
@@ -70,9 +58,9 @@ bool IMUPreintegrationFactor::Evaluate(double const *const *parameters,
 
   // Compute Jacobians
   std::vector<Eigen::Matrix<double, 15, 15>> jac_vec =
-      computeRawJacobians(X_i, X_j);
-  Eigen::Matrix<double, 15, 15> jac_i = jac_vec[0];
-  Eigen::Matrix<double, 15, 15> jac_j = jac_vec[1];
+      helper.computeRawJacobians(X_i, X_j);
+  Eigen::Matrix<double, 15, 15> jac_i = sqrt_info * jac_vec[0];
+  Eigen::Matrix<double, 15, 15> jac_j = sqrt_info * jac_vec[1];
   if (jacobians) {
     // Jacobian of residual with respect to extended pose km1
     if (jacobians[0]) {
@@ -85,7 +73,6 @@ bool IMUPreintegrationFactor::Evaluate(double const *const *parameters,
       jac_pose_i_ceres.setZero();
       jac_pose_i_ceres.leftCols(3) = jac_extended_pose_i.leftCols(3);
       jac_pose_i_ceres.rightCols(6) = jac_extended_pose_i.rightCols(6);
-      jac_pose_i_ceres = sqrt_info * jac_pose_i_ceres;
     }
     // Jacobian w.r.t. bias km1
     if (jacobians[1]) {
@@ -95,7 +82,6 @@ bool IMUPreintegrationFactor::Evaluate(double const *const *parameters,
           jac_bias_i_ceres(jacobians[1]);
       jac_bias_i_ceres.setZero();
       jac_bias_i_ceres = jac_bias_i;
-      jac_bias_i_ceres = sqrt_info * jac_bias_i_ceres;
     }
     // Jacobian w.r.t. extended pose k
     if (jacobians[2]) {
@@ -106,7 +92,6 @@ bool IMUPreintegrationFactor::Evaluate(double const *const *parameters,
       jac_pose_j_ceres.setZero();
       jac_pose_j_ceres.leftCols(3) = jac_extended_pose_j.leftCols(3);
       jac_pose_j_ceres.rightCols(6) = jac_extended_pose_j.rightCols(6);
-      jac_pose_j_ceres = sqrt_info * jac_pose_j_ceres;
     }
 
     if (jacobians[3]) {
@@ -116,365 +101,7 @@ bool IMUPreintegrationFactor::Evaluate(double const *const *parameters,
           jac_bias_j_ceres(jacobians[3]);
       jac_bias_j_ceres.setZero();
       jac_bias_j_ceres = jac_bias_j;
-      jac_bias_j_ceres = sqrt_info * jac_bias_j_ceres;
     }
   }
   return true;
-}
-
-Eigen::Matrix<double, 15, 1>
-IMUPreintegrationFactor::computeRawError(const IMUStateHolder &X_i,
-                                         const IMUStateHolder &X_j) const {
-  // Correct RMI for new value of bias
-  Eigen::Matrix<double, 5, 5> Y_meas = getUpdatedRMI(X_i);
-  // Get predicted RMI based on states and form the error
-  Eigen::Matrix<double, 5, 5> Y_pred = predictNavRMI(X_i, X_j);
-
-  // Compute the error on the navigation RMI
-  Eigen::Matrix<double, 9, 1> e_nav = Eigen::Matrix<double, 9, 1>::Zero();
-  if (pose_rep == ExtendedPoseRepresentation::SE23) {
-    // If we're using SE_2(3) representation, compute the error between the
-    // predicted and measured RMI on SE_2(3)
-    e_nav = SE23::minus(Y_pred, Y_meas, direction);
-  } else if (pose_rep == ExtendedPoseRepresentation::Decoupled) {
-    // Else, we compute the error using the decoupled representation
-    e_nav.block<3, 1>(0, 0) = SO3::minus(Y_pred.block<3, 3>(0, 0),
-                                         Y_meas.block<3, 3>(0, 0), direction);
-    e_nav.block<3, 1>(3, 0) =
-        Y_pred.block<3, 1>(0, 3) - Y_meas.block<3, 1>(0, 3);
-    e_nav.block<3, 1>(6, 0) =
-        Y_pred.block<3, 1>(0, 4) - Y_meas.block<3, 1>(0, 4);
-  }
-
-  Eigen::Vector3d e_bg = X_j.bias_gyro - X_i.bias_gyro;
-  Eigen::Vector3d e_ba = X_j.bias_accel - X_i.bias_accel;
-
-  Eigen::Matrix<double, 15, 1> error;
-  error.block<9, 1>(0, 0) = e_nav;
-  error.block<3, 1>(9, 0) = e_bg;
-  error.block<3, 1>(12, 0) = e_ba;
-  return error;
-}
-
-Eigen::Matrix<double, 5, 5>
-IMUPreintegrationFactor::getUpdatedRMI(const IMUStateHolder &X_i) const {
-  Eigen::Matrix<double, 6, 1> dbias;
-  Eigen::Vector3d d_bg = X_i.bias_gyro - rmi.gyro_bias;
-  Eigen::Vector3d d_ba = X_i.bias_accel - rmi.accel_bias;
-  dbias.block<3, 1>(0, 0) = d_bg;
-  dbias.block<3, 1>(3, 0) = d_ba;
-
-  Eigen::Matrix<double, 5, 5> delta_X = Eigen::Matrix<double, 5, 5>::Identity();
-  delta_X.block<3, 3>(0, 0) = rmi.delta_U.block<3, 3>(0, 0);
-  delta_X.block<3, 1>(0, 3) = rmi.delta_U.block<3, 1>(0, 3);
-  delta_X.block<3, 1>(0, 4) = rmi.delta_U.block<3, 1>(0, 4);
-
-  // If we're using an SE_2(3) representation, perform first-order
-  // bias correct directly on the group
-  if (pose_rep == ExtendedPoseRepresentation::SE23) {
-    if (direction == LieDirection::left) {
-      return SE23::expMap(rmi.bias_jacobian * dbias) * delta_X;
-    } else if (direction == LieDirection::right) {
-      return delta_X * SE23::expMap(rmi.bias_jacobian * dbias);
-    } else {
-      std::cout << "WARNING: Unknown Lie direction!" << std::endl;
-      return Eigen::Matrix<double, 5, 5>::Identity();
-    }
-  }
-
-  // Perform first-order bias correct for decoupled representation
-  // This corresponds to the scheme presented in "On-Manifold Preintegration for
-  // Real-Time "Visual–Inertial Odometry" by Forster et al. (2017). (see
-  // equation (44))
-  else if (pose_rep == ExtendedPoseRepresentation::Decoupled) {
-    // Extract subcomponents
-    Eigen::Matrix3d delta_C = delta_X.block<3, 3>(0, 0);
-    Eigen::Vector3d delta_v = delta_X.block<3, 1>(0, 3);
-    Eigen::Vector3d delta_r = delta_X.block<3, 1>(0, 4);
-
-    // Extract relevant parts of the bias Jacobian
-    Eigen::Matrix3d dC_dbg = rmi.bias_jacobian.block<3, 3>(0, 0);
-
-    Eigen::Matrix<double, 3, 6> dv_db = rmi.bias_jacobian.block<3, 6>(3, 0);
-    Eigen::Matrix<double, 3, 6> dr_db = rmi.bias_jacobian.block<3, 6>(6, 0);
-
-    Eigen::Vector3d delta_v_updated = delta_v + dv_db * dbias;
-    Eigen::Vector3d delta_r_updated = delta_r + dr_db * dbias;
-
-    Eigen::Matrix3d delta_C_updated;
-    // Update delta_C with the correct perturbation
-    if (direction == LieDirection::left) {
-      delta_C_updated = SO3::expMap(dC_dbg * d_bg) * delta_C;
-    } else if (direction == LieDirection::right) {
-      // Perform first-order correction
-      delta_C_updated = delta_C * SO3::expMap(dC_dbg * d_bg);
-    }
-    // Assemble the updated delta_X matrix
-    Eigen::Matrix<double, 5, 5> delta_X_updated =
-        Eigen::Matrix<double, 5, 5>::Identity();
-    delta_X_updated.block<3, 3>(0, 0) = delta_C_updated;
-    delta_X_updated.block<3, 1>(0, 3) = delta_v_updated;
-    delta_X_updated.block<3, 1>(0, 4) = delta_r_updated;
-    return delta_X_updated;
-  }
-  else {
-    LOG(ERROR) << "Unknown ExtendedPoseRepresentation type!";
-    return Eigen::Matrix<double, 5, 5>::Identity();
-  }
-}
-
-Eigen::Matrix<double, 5, 5>
-IMUPreintegrationFactor::predictNavRMI(const IMUStateHolder &X_i,
-                                       const IMUStateHolder &X_j) const {
-  Eigen::Vector3d g_a = rmi.gravity;
-  Eigen::Matrix3d C_i = X_i.attitude;
-  Eigen::Vector3d v_i = X_i.velocity;
-  Eigen::Vector3d r_i = X_i.position;
-
-  Eigen::Matrix3d C_j = X_j.attitude;
-  Eigen::Vector3d v_j = X_j.velocity;
-  Eigen::Vector3d r_j = X_j.position;
-
-  double delta_t = rmi.end_stamp - rmi.start_stamp;
-  Eigen::Matrix3d delta_C = C_i.transpose() * C_j;
-  Eigen::Vector3d delta_v = C_i.transpose() * (v_j - v_i - g_a * delta_t);
-  Eigen::Vector3d delta_r = C_i.transpose() * (r_j - r_i - v_i * delta_t -
-                                               0.5 * g_a * (delta_t * delta_t));
-
-  Eigen::Matrix<double, 5, 5> delta_X_nav =
-      SE23::fromComponents(delta_C, delta_v, delta_r);
-  return delta_X_nav;
-}
-
-std::vector<Eigen::Matrix<double, 15, 15>>
-IMUPreintegrationFactor::computeRawJacobians(const IMUStateHolder &X_i,
-                                             const IMUStateHolder &X_j) const {
-  if (pose_rep == ExtendedPoseRepresentation::SE23) {
-    if (direction == LieDirection::left) {
-      return computeRawJacobiansLeftSE23(X_i, X_j);
-    } else if (direction == LieDirection::right) {
-      return computeRawJacobiansRightSE23(X_i, X_j);
-    } else {
-      std::cout << "WARNING: Unknown Lie direction!" << std::endl;
-      return std::vector<Eigen::Matrix<double, 15, 15>>();
-    }
-  } else if (pose_rep == ExtendedPoseRepresentation::Decoupled) {
-    if (direction == LieDirection::left) {
-      LOG(INFO) << "Left Jacobians not implemented for decoupled navigation "
-                   "state representation.";
-    } else if (direction == LieDirection::right) {
-      return computeRawJacobiansRightDecoupled(X_i, X_j);
-    } else {
-      LOG(INFO) << "Unknown Lie direction for decoupled navigation state "
-                   "representation.";
-    }
-  }
-}
-
-std::vector<Eigen::Matrix<double, 15, 15>>
-IMUPreintegrationFactor::computeRawJacobiansLeftSE23(
-    const IMUStateHolder &X_i, const IMUStateHolder &X_j) const {
-  // Extract individual states
-  Eigen::Vector3d g_a = rmi.gravity;
-  Eigen::Matrix3d C_i = X_i.attitude;
-  Eigen::Vector3d v_i = X_i.velocity;
-  Eigen::Vector3d r_i = X_i.position;
-  Eigen::Vector3d ba_i = X_i.bias_accel;
-
-  Eigen::Vector3d v_j = X_j.velocity;
-  Eigen::Vector3d r_j = X_j.position;
-
-  Eigen::Matrix<double, 5, 5> del_Xy_mat = getUpdatedRMI(X_i);
-  Eigen::Matrix<double, 5, 5> del_Xx_mat = predictNavRMI(X_i, X_j);
-
-  // Extract required subcomponents of matrix
-  Eigen::Matrix<double, 3, 1> del_Xx_v = del_Xx_mat.block<3, 1>(0, 3);
-  Eigen::Matrix<double, 3, 1> del_Xx_r = del_Xx_mat.block<3, 1>(0, 4);
-  double delta_t = rmi.end_stamp - rmi.start_stamp;
-
-  // Jacobian of \Delta X^X with respect to X_i
-  Eigen::Matrix<double, 15, 15> D_delta_xx_Xi =
-      Eigen::Matrix<double, 15, 15>::Zero();
-  D_delta_xx_Xi.block<3, 3>(0, 0) = -C_i.transpose();
-  D_delta_xx_Xi.block<3, 3>(3, 0) = C_i.transpose() * SO3::cross(v_i);
-  D_delta_xx_Xi.block<3, 3>(3, 3) = -C_i.transpose();
-  D_delta_xx_Xi.block<3, 3>(6, 0) =
-      C_i.transpose() * SO3::cross(r_i + v_i * delta_t);
-  D_delta_xx_Xi.block<3, 3>(6, 3) = -delta_t * C_i.transpose();
-  D_delta_xx_Xi.block<3, 3>(6, 6) = -C_i.transpose();
-  D_delta_xx_Xi.block<6, 6>(9, 9) = -Eigen::Matrix<double, 6, 6>::Identity();
-
-  // Compute Jacobian of error w.r.t del_Xy
-  Eigen::Matrix<double, 6, 1> dbias;
-  dbias.block<3, 1>(0, 0) = X_i.bias_gyro - rmi.gyro_bias;
-  dbias.block<3, 1>(3, 0) = X_i.bias_accel - rmi.accel_bias;
-  Eigen::Matrix<double, 9, 6> bias_jac = rmi.bias_jacobian;
-  Eigen::Matrix<double, 9, 1> tau = bias_jac * dbias;
-
-  Eigen::Matrix<double, 9, 6> Ji_X_b =
-      SE23::leftJacobian(bias_jac * dbias) * bias_jac;
-  Eigen::Matrix<double, 15, 15> xi_i_y = Eigen::Matrix<double, 15, 15>::Zero();
-  xi_i_y.block<9, 6>(0, 9) = Ji_X_b;
-
-  // If we want to include the group jacobians, need to compute
-  // the Jacobian of the error with respect to the delta_X^Y
-  // and delta_X^X
-  Eigen::Matrix<double, 15, 15> De_D_delta_xy =
-      -Eigen::Matrix<double, 15, 15>::Identity();
-  Eigen::Matrix<double, 15, 15> De_D_delta_xx =
-      Eigen::Matrix<double, 15, 15>::Identity();
-
-  if (use_group_jacobians) {
-    Eigen::Matrix<double, 15, 1> error = computeRawError(X_i, X_j);
-    Eigen::Matrix<double, 9, 1> e_nav = error.block<9, 1>(0, 0);
-
-    De_D_delta_xx.block<9, 9>(0, 0) = SE23::leftJacobianInverse(e_nav);
-    De_D_delta_xy.block<9, 9>(0, 0) = -SE23::rightJacobianInverse(e_nav);
-  }
-
-  Eigen::Matrix<double, 15, 15> jac_i =
-      De_D_delta_xy * xi_i_y + De_D_delta_xx * D_delta_xx_Xi;
-
-  // Compute Jacobians of error w.r.t X_j
-  Eigen::Matrix3d Jj_C_C = C_i.transpose();
-  Eigen::Matrix3d Jj_v_C = -C_i.transpose() * SO3::cross(v_j) +
-                           SO3::cross(del_Xx_v) * C_i.transpose();
-  Eigen::Matrix3d Jj_v_v = C_i.transpose();
-  Eigen::Matrix3d Jj_r_C = -C_i.transpose() * SO3::cross(r_j) +
-                           SO3::cross(del_Xx_r) * C_i.transpose();
-  Eigen::Matrix3d Jj_r_r = C_i.transpose();
-  // Jacobian of \Delta X^X with respect to X_j
-  Eigen::Matrix<double, 15, 15> xi_j_x = Eigen::Matrix<double, 15, 15>::Zero();
-  xi_j_x.block<3, 3>(0, 0) = Jj_C_C;
-  xi_j_x.block<3, 3>(3, 0) = Jj_v_C;
-  xi_j_x.block<3, 3>(3, 3) = Jj_v_v;
-  xi_j_x.block<3, 3>(6, 0) = Jj_r_C;
-  xi_j_x.block<3, 3>(6, 6) = Jj_r_r;
-  xi_j_x.block<6, 6>(9, 9) = Eigen::Matrix<double, 6, 6>::Identity();
-  Eigen::Matrix<double, 15, 15> jac_j = De_D_delta_xx * xi_j_x;
-
-  std::vector<Eigen::Matrix<double, 15, 15>> raw_jacobians;
-  raw_jacobians.push_back(jac_i);
-  raw_jacobians.push_back(jac_j);
-  return raw_jacobians;
-}
-
-std::vector<Eigen::Matrix<double, 15, 15>>
-IMUPreintegrationFactor::computeRawJacobiansRightSE23(
-    const IMUStateHolder &X_i, const IMUStateHolder &X_j) const {
-  Eigen::Matrix<double, 5, 5> del_Xx_mat = predictNavRMI(X_i, X_j);
-
-  // Extract required subcomponents of matrix
-  Eigen::Matrix3d del_Xx_C = del_Xx_mat.block<3, 3>(0, 0);
-  Eigen::Vector3d del_Xx_v = del_Xx_mat.block<3, 1>(0, 3);
-  Eigen::Vector3d del_Xx_r = del_Xx_mat.block<3, 1>(0, 4);
-  double delta_t = rmi.end_stamp - rmi.start_stamp;
-
-  // Compute Jacobian of \Delta_X^X with respect to X_i
-  Eigen::Matrix<double, 15, 15> xi_i_x = Eigen::Matrix<double, 15, 15>::Zero();
-  xi_i_x.block<3, 3>(0, 0) = -del_Xx_C.transpose();
-  xi_i_x.block<3, 3>(3, 0) = del_Xx_C.transpose() * SO3::cross(del_Xx_v);
-  xi_i_x.block<3, 3>(3, 3) = -del_Xx_C.transpose();
-  xi_i_x.block<3, 3>(6, 0) = del_Xx_C.transpose() * SO3::cross(del_Xx_r);
-  xi_i_x.block<3, 3>(6, 3) = -delta_t * del_Xx_C.transpose();
-  xi_i_x.block<3, 3>(6, 6) = -del_Xx_C.transpose();
-  xi_i_x.block<6, 6>(9, 9) = -Eigen::Matrix<double, 6, 6>::Identity();
-
-  // Compute Jacobian of error with respect to \Delta X^Y
-  Eigen::Matrix<double, 6, 1> dbias;
-  dbias.block<3, 1>(0, 0) = X_i.bias_gyro - rmi.gyro_bias;
-  dbias.block<3, 1>(3, 0) = X_i.bias_accel - rmi.accel_bias;
-  Eigen::Matrix<double, 9, 6> bias_jac = rmi.bias_jacobian;
-  Eigen::Matrix<double, 9, 1> tau = bias_jac * dbias;
-  Eigen::Matrix<double, 9, 6> Ji_X_b = SE23::rightJacobian(tau) * bias_jac;
-
-  Eigen::Matrix<double, 15, 15> xi_i_y = Eigen::Matrix<double, 15, 15>::Zero();
-  xi_i_y.block<9, 6>(0, 9) = Ji_X_b;
-
-  // Jacobian of \Delta X^X with respect to X_j
-  Eigen::Matrix<double, 15, 15> jac_j =
-      Eigen::Matrix<double, 15, 15>::Identity();
-
-  Eigen::Matrix<double, 15, 15> De_D_delta_xy =
-      -Eigen::Matrix<double, 15, 15>::Identity();
-  Eigen::Matrix<double, 15, 15> De_D_delta_xx =
-      Eigen::Matrix<double, 15, 15>::Identity();
-
-  if (use_group_jacobians) {
-    Eigen::Matrix<double, 15, 1> error = computeRawError(X_i, X_j);
-    Eigen::Matrix<double, 9, 1> e_nav = error.block<9, 1>(0, 0);
-    De_D_delta_xy.block<9, 9>(0, 0) = -SE23::leftJacobianInverse(e_nav);
-    De_D_delta_xx.block<9, 9>(0, 0) = SE23::rightJacobianInverse(e_nav);
-  }
-
-  Eigen::Matrix<double, 15, 15> jac_i =
-      De_D_delta_xy * xi_i_y + De_D_delta_xx * xi_i_x;
-  jac_j = De_D_delta_xx * jac_j;
-
-  std::vector<Eigen::Matrix<double, 15, 15>> raw_jacobians;
-  raw_jacobians.push_back(jac_i);
-  raw_jacobians.push_back(jac_j);
-  return raw_jacobians;
-}
-
-std::vector<Eigen::Matrix<double, 15, 15>>
-IMUPreintegrationFactor::computeRawJacobiansRightDecoupled(
-    const IMUStateHolder &X_i, const IMUStateHolder &X_j) const {
-  Eigen::Matrix<double, 5, 5> del_Xx_mat = predictNavRMI(X_i, X_j);
-
-  // Extract required subcomponents of matrix
-  Eigen::Matrix3d del_Xx_C = del_Xx_mat.block<3, 3>(0, 0);
-  Eigen::Vector3d del_Xx_v = del_Xx_mat.block<3, 1>(0, 3);
-  Eigen::Vector3d del_Xx_r = del_Xx_mat.block<3, 1>(0, 4);
-  double delta_t = rmi.end_stamp - rmi.start_stamp;
-
-  Eigen::Matrix3d C_i = X_i.attitude;
-
-  // Compute Jacobian of \Delta_X^X with respect to X_i
-  Eigen::Matrix<double, 15, 15> D_delta_xx_Xi =
-      Eigen::Matrix<double, 15, 15>::Zero();
-  D_delta_xx_Xi.block<3, 3>(0, 0) = -del_Xx_C.transpose();
-  D_delta_xx_Xi.block<3, 3>(3, 0) = SO3::cross(del_Xx_v);
-  D_delta_xx_Xi.block<3, 3>(3, 3) = -C_i.transpose();
-  D_delta_xx_Xi.block<3, 3>(6, 0) = SO3::cross(del_Xx_r);
-  D_delta_xx_Xi.block<3, 3>(6, 3) = -delta_t * C_i.transpose();
-  D_delta_xx_Xi.block<3, 3>(6, 6) = -C_i.transpose();
-  D_delta_xx_Xi.block<6, 6>(9, 9) = -Eigen::Matrix<double, 6, 6>::Identity();
-
-  // Compute Jacobian of \Delta_X^Y with respect to X_i
-  // We need the bias Jacobian here
-  Eigen::Matrix<double, 9, 6> bias_jac = rmi.bias_jacobian;
-
-  Eigen::Matrix<double, 15, 15> D_delta_xy_Xi =
-      Eigen::Matrix<double, 15, 15>::Zero();
-  D_delta_xy_Xi.block<9, 6>(0, 9) = bias_jac;
-
-  // Compute Jacobian of \Delta X^X with respect to X_j
-  Eigen::Matrix<double, 15, 15> D_delta_xx_Xj =
-      Eigen::Matrix<double, 15, 15>::Identity();
-  D_delta_xx_Xj.block<3, 3>(3, 3) = C_i.transpose();
-  D_delta_xx_Xj.block<3, 3>(6, 6) = C_i.transpose();
-
-  // Group Jacobians
-  Eigen::Matrix<double, 15, 15> De_D_delta_xy =
-      -Eigen::Matrix<double, 15, 15>::Identity();
-  Eigen::Matrix<double, 15, 15> De_D_delta_xx =
-      Eigen::Matrix<double, 15, 15>::Identity();
-
-  if (use_group_jacobians) {
-    Eigen::Matrix<double, 15, 1> error = computeRawError(X_i, X_j);
-    Eigen::Matrix<double, 3, 1> e_att = error.block<3, 1>(0, 0);
-
-    De_D_delta_xx.block<3, 3>(0, 0) = SO3::rightJacobianInverse(e_att);
-    De_D_delta_xy.block<3, 3>(0, 0) = -SO3::leftJacobianInverse(e_att);
-  }
-
-  Eigen::Matrix<double, 15, 15> jac_i =
-      De_D_delta_xx * D_delta_xx_Xi + De_D_delta_xy * D_delta_xy_Xi;
-  Eigen::Matrix<double, 15, 15> jac_j = De_D_delta_xx * D_delta_xx_Xj;
-
-  std::vector<Eigen::Matrix<double, 15, 15>> raw_jacobians;
-  raw_jacobians.push_back(jac_i);
-  raw_jacobians.push_back(jac_j);
-  return raw_jacobians;
 }

--- a/src/factors/IMUPriorFactor.cpp
+++ b/src/factors/IMUPriorFactor.cpp
@@ -8,32 +8,43 @@
 IMUPriorFactor::IMUPriorFactor(
     const Eigen::Matrix<double, 5, 5> &prior_nav_state,
     const Eigen::Matrix<double, 6, 1> &prior_imu_bias,
-    const Eigen::Matrix<double, 15, 15> &prior_covariance, LieDirection direction)
+    const Eigen::Matrix<double, 15, 15> &prior_covariance,
+    LieDirection direction, ExtendedPoseRepresentation pose_rep)
     : prior_nav_state_(prior_nav_state), prior_bias_(prior_imu_bias),
-      prior_covariance_(prior_covariance), direction_(direction) {
+      prior_covariance_(prior_covariance), direction_(direction),
+      pose_rep_(pose_rep) {
   // Compute square root info matrix
   sqrt_info_ = computeSquareRootInformation(prior_covariance_);
 }
 
 bool IMUPriorFactor::Evaluate(double const *const *parameters,
                               double *residuals, double **jacobians) const {
-  // Extract prior state
-  Eigen::Matrix3d C;
-  Eigen::Vector3d v;
-  Eigen::Vector3d r;
+  // Extract our state
   Eigen::Matrix<double, 5, 5> T_state =
       SE23::fromCeresParameters(parameters[0]);
-  SE23::toComponents(T_state, C, v, r);
-
-  Eigen::Vector3d bg(parameters[1][0], parameters[1][1], parameters[1][2]);
-  Eigen::Vector3d ba(parameters[1][3], parameters[1][4], parameters[1][5]);
+  Eigen::Vector3d bg = Eigen::Map<const Eigen::Vector3d>(parameters[1]);
+  Eigen::Vector3d ba = Eigen::Map<const Eigen::Vector3d>(parameters[1] + 3);
 
   // Compute the resudual
   Eigen::Matrix<double, 15, 1> error;
-  error.block<9, 1>(0, 0) =
-      SE23::minus(T_state, prior_nav_state_, direction_);
+  if (pose_rep_ == ExtendedPoseRepresentation::SE23) {
+    // Compute the error directly on SE_2(3)
+    error.block<9, 1>(0, 0) =
+        SE23::minus(T_state, prior_nav_state_, direction_);
+  } else if (pose_rep_ == ExtendedPoseRepresentation::Decoupled) {
+    Eigen::Matrix3d C = T_state.block<3, 3>(0, 0);
+    Eigen::Vector3d v = T_state.block<3, 1>(0, 3);
+    Eigen::Vector3d r = T_state.block<3, 1>(0, 4);
+    Eigen::Matrix3d C_prior = prior_nav_state_.block<3, 3>(0, 0);
+    Eigen::Vector3d v_prior = prior_nav_state_.block<3, 1>(0, 3);
+    Eigen::Vector3d r_prior = prior_nav_state_.block<3, 1>(0, 4);
+    error.block<3, 1>(0, 0) = SO3::minus(C, C_prior, direction_);
+    error.block<3, 1>(3, 0) = v - v_prior;
+    error.block<3, 1>(6, 0) = r - r_prior;
+  }
+
   error.block<3, 1>(9, 0) = bg - prior_bias_.block<3, 1>(0, 0);
-  error.block<3, 1>(12, 0) = ba - prior_bias_.block<3, 1>(3, 0);  
+  error.block<3, 1>(12, 0) = ba - prior_bias_.block<3, 1>(3, 0);
 
   Eigen::Map<Eigen::Matrix<double, 15, 1>> residual(residuals);
   residual = error;

--- a/src/factors/IMUPriorFactor.cpp
+++ b/src/factors/IMUPriorFactor.cpp
@@ -14,7 +14,7 @@ IMUPriorFactor::IMUPriorFactor(
       prior_covariance_(prior_covariance), direction_(direction),
       pose_rep_(pose_rep) {
   // Compute square root info matrix
-  sqrt_info_ = computeSquareRootInformation(prior_covariance_);
+  sqrt_info_ = ceres_nav::computeSquareRootInformation(prior_covariance_);
 }
 
 bool IMUPriorFactor::Evaluate(double const *const *parameters,

--- a/src/factors/RelativeLandmarkFactor.cpp
+++ b/src/factors/RelativeLandmarkFactor.cpp
@@ -8,20 +8,10 @@
 bool RelativeLandmarkFactor::Evaluate(double const *const *parameters,
                                       double *residuals,
                                       double **jacobians) const {
-  // Extract extended pose
-  Eigen::Matrix3d C_ab;
-  Eigen::Vector3d v_zw_a;
-  Eigen::Vector3d r_zw_a;
-
-  if (pose_type == "SE3") {
-    Eigen::Matrix<double, 4, 4> T_ab = SE3::fromCeresParameters(parameters[0]);
-    SE3::toComponents(T_ab, C_ab, r_zw_a);
-  } else if (pose_type == "SE23") {
-    Eigen::Matrix<double, 5, 5> T_ab = SE23::fromCeresParameters(parameters[0]);
-    SE23::toComponents(T_ab, C_ab, v_zw_a, r_zw_a);
-  } else {
-    throw std::runtime_error("Unknown pose type");
-  }
+  // Extract extended pose parameters
+  Eigen::Matrix<double, 5, 5> T_ab = SE23::fromCeresParameters(parameters[0]);
+  Eigen::Matrix3d C_ab = T_ab.block<3, 3>(0, 0);
+  Eigen::Vector3d r_zw_a = T_ab.block<3, 1>(0, 4);
 
   // Extract landmark position
   Eigen::Vector3d r_pw_a(parameters[1][0], parameters[1][1], parameters[1][2]);
@@ -33,39 +23,51 @@ bool RelativeLandmarkFactor::Evaluate(double const *const *parameters,
   Eigen::Map<Eigen::Vector3d> residual(residuals);
   residual = sqrt_info * error;
 
+  // Compute the Jacobians of the factor
+  // with respect to the pose and landmark parameters.
+  // The Jacobians depend on the pose representation used and the Lie direction.
+  Eigen::Matrix3d att_jacobian = Eigen::Matrix3d::Zero();
+  Eigen::Matrix3d pos_jacobian = Eigen::Matrix3d::Zero();
+
+  switch (pose_type) {
+  case ExtendedPoseRepresentation::SE23: {
+    if (direction == LieDirection::right) {
+      att_jacobian = -SO3::cross(y_check);
+      pos_jacobian = Eigen::Matrix3d::Identity();
+    } else if (direction == LieDirection::left) {
+      att_jacobian = -C_ab.transpose() * SO3::cross(r_pw_a);
+      pos_jacobian = C_ab.transpose();
+    } else {
+      std::cerr << "Invalid LieDirection" << std::endl;
+    }
+    break;
+  }
+  case ExtendedPoseRepresentation::Decoupled: {
+    if (direction == LieDirection::right) {
+      att_jacobian = -SO3::cross(y_check);
+      pos_jacobian = C_ab.transpose();
+    } else if (direction == LieDirection::left) {
+      att_jacobian = -C_ab.transpose() * SO3::cross(r_pw_a - r_zw_a);
+      pos_jacobian = C_ab.transpose();
+    } else {
+      std::cerr << "Invalid LieDirection" << std::endl;
+    }
+    break;
+  }
+  default:
+    std::cerr << "Unknown state representation type" << std::endl;
+  }
+
+  att_jacobian *= sqrt_info;
+  pos_jacobian *= sqrt_info;
   // Compute the Jacobians
   if (jacobians) {
     if (jacobians[0]) {
-      // Compute jacobian with respect to attitude and position
-      Eigen::Matrix3d jac_att = Eigen::Matrix3d::Zero();
-      Eigen::Matrix3d jac_position = Eigen::Matrix3d::Zero();
-      if (direction == LieDirection::left) {
-        jac_att = -C_ab.transpose() * SO3::cross(r_pw_a);
-        jac_position = C_ab.transpose();
-      } else if (direction == LieDirection::right) {
-        jac_att = -SO3::cross(y_check);
-        jac_position = Eigen::Matrix3d::Identity();
-      } else {
-        std::cerr << "Invalid LieDirection" << std::endl;
-      }
-
-      // size of Jacobian depends on the pose type
-      if (pose_type == "SE3") {
-        Eigen::Map<Eigen::Matrix<double, 3, 12, Eigen::RowMajor>> jac_pose(
-            jacobians[0]);
-
-        jac_pose.setZero();
-        jac_pose.leftCols(3) = jac_att;
-        jac_pose.rightCols(3) = jac_position;
-        jac_pose = sqrt_info * jac_pose;
-      } else if (pose_type == "SE23") {
-        Eigen::Map<Eigen::Matrix<double, 3, 15, Eigen::RowMajor>> jac_pose(
-            jacobians[0]);
-        jac_pose.setZero();
-        jac_pose.leftCols(3) = jac_att;
-        jac_pose.rightCols(3) = jac_position;
-        jac_pose = sqrt_info * jac_pose;
-      }
+      Eigen::Map<Eigen::Matrix<double, 3, 15, Eigen::RowMajor>> jac_pose(
+          jacobians[0]);
+      jac_pose.setZero();
+      jac_pose.leftCols(3) = att_jacobian;
+      jac_pose.rightCols(3) = pos_jacobian;
     }
     if (jacobians[1]) {
       // Jacobian of residual with respect to landmark parameters

--- a/src/imu/IMUHelper.cpp
+++ b/src/imu/IMUHelper.cpp
@@ -73,7 +73,7 @@ Eigen::Matrix<double, 9, 6> createLMatrix(const Eigen::Vector3d &unbiased_gyro,
   Eigen::Vector3d om = unbiased_gyro;
   Eigen::Vector3d om_dt = om * dt;
   Eigen::Matrix3d J_att_inv_times_N =
-      SO3::leftJacobianInv(om_dt) * createNMatrix(om_dt);
+      SO3::leftJacobianInverse(om_dt) * createNMatrix(om_dt);
   Eigen::VectorXd xi(9);
   xi.segment<3>(0) = dt * om;
   xi.segment<3>(3) = dt * a;

--- a/src/imu/IMUIncrement.cpp
+++ b/src/imu/IMUIncrement.cpp
@@ -87,8 +87,6 @@ void IMUIncrement::propagateCovarianceAndBiasJacobian(
     computeContinuousTimeJacobiansSE23(C, v, r, omega, accel, A_ct, L_ct);
   } else if (pose_rep == ExtendedPoseRepresentation::Decoupled) {
     computeContinuousTimeJacobiansDecoupled(C, v, r, omega, accel, A_ct, L_ct);
-    LOG(WARNING) << "Decoupled representation is not fully implemented yet. "
-                 << "Using SE23 representation for now.";
   } else {
     LOG(FATAL) << "Unknown pose representation: " << static_cast<int>(pose_rep);
   }
@@ -120,7 +118,7 @@ void IMUIncrement::computeContinuousTimeJacobiansDecoupled(
 
   if (direction == LieDirection::left) {
     LOG(INFO) << "Left lie direction for decoupled navigation state "
-                 "representation not yet supported!"; 
+                 "representation not yet supported with IMU increment!"; 
   } else if (direction == LieDirection::right) {
     Eigen::Vector3d unbiased_gyro = omega - gyro_bias;
     Eigen::Vector3d unbiased_accel = accel - accel_bias;

--- a/src/imu/IMUIncrement.cpp
+++ b/src/imu/IMUIncrement.cpp
@@ -126,7 +126,7 @@ void IMUIncrement::computeContinuousTimeJacobiansDecoupled(
     A_ct.block<3, 3>(0, 0) = -SO3::cross(unbiased_gyro);
     A_ct.block<3, 3>(0, 9) = -Eigen::Matrix3d::Identity();
     A_ct.block<3, 3>(3, 0) = -C * SO3::cross(unbiased_accel);
-    A_ct.block<3, 3>(0, 9) = -C;
+    A_ct.block<3, 3>(3, 12) = -C;
     A_ct.block<3, 3>(6, 3) = Eigen::Matrix3d::Identity();
 
     L_ct.block<3, 3>(0, 0) = Eigen::Matrix3d::Identity();

--- a/src/imu/IMUIncrement.cpp
+++ b/src/imu/IMUIncrement.cpp
@@ -92,8 +92,8 @@ void IMUIncrement::propagateCovarianceAndBiasJacobian(
   }
 
   Eigen::MatrixXd A_d, Q_d;
-  discretizeSystem(A_ct, L_ct, Q_ct, dt, A_d, Q_d,
-                   DiscretizationMethod::TaylorSeries);
+  ceres_nav::discretizeSystem(A_ct, L_ct, Q_ct, dt, A_d, Q_d,
+                   ceres_nav::DiscretizationMethod::TaylorSeries);
   Q_d = 0.5 * (Q_d + Q_d.transpose());
 
   // Propagate Jacobian forward and extract bias portion

--- a/src/imu/IMUIncrement.cpp
+++ b/src/imu/IMUIncrement.cpp
@@ -4,18 +4,21 @@
 #include "lie/SE23.h"
 #include "lie/SO3.h"
 
+#include "utils/Utils.h"
+
 #include <cmath>
-#include <iostream>
+
+#include <glog/logging.h>
 
 IMUIncrement::IMUIncrement(Eigen::Matrix<double, 12, 12> Q_ct_,
                            Eigen::Vector3d init_gyro_bias,
                            Eigen::Vector3d init_accel_bias, double init_stamp,
                            const Eigen::Vector3d &gravity_,
-                           const std::string &covariance_prop_method_,
-                           const LieDirection &direction_)
+                           const LieDirection &direction_,
+                           const ExtendedPoseRepresentation &pose_rep_)
     : Q_ct{Q_ct_}, gyro_bias{init_gyro_bias}, accel_bias{init_accel_bias},
       start_stamp{init_stamp}, end_stamp{init_stamp}, gravity{gravity_},
-      covariance_prop_method{covariance_prop_method_}, direction{direction_} {
+      direction{direction_}, pose_rep{pose_rep_} {
   // Set bias Jacobians to zero
   bias_jacobian.setZero();
 
@@ -26,7 +29,7 @@ IMUIncrement::IMUIncrement(Eigen::Matrix<double, 12, 12> Q_ct_,
   dt_total = 0.0;
 }
 
-void IMUIncrement::reset(double new_start_stamp, 
+void IMUIncrement::reset(double new_start_stamp,
                          const Eigen::Vector3d &new_gyro_bias,
                          const Eigen::Vector3d &new_accel_bias) {
   gyro_bias = new_gyro_bias;
@@ -61,31 +64,87 @@ void IMUIncrement::propagate(double dt, const Eigen::Vector3d &omega,
   Eigen::Matrix<double, 5, 5> U_mat =
       createUMatrix(unbiased_gyro, unbiased_accel, dt);
 
-  if (covariance_prop_method.compare("discrete") == 0) {
-    std::cout << "Warning: Discrete covariance propagation not supported!"
-              << std::endl;
-  } else if (covariance_prop_method.compare("continuous") == 0) {
-    propagateCovarianceAndBiasJacContinuous(dt, omega, accel);
-  } else {
-    std::cout << "Covariance propagation method undefined!" << std::endl;
-  }
-
+  // Propagate forward the covariance and bias Jacobian
+  propagateCovarianceAndBiasJacobian(dt, omega, accel);
   symmetrize();
 
   // Update RMI
   delta_U = delta_U * U_mat;
 }
 
-void IMUIncrement::propagateCovarianceAndBiasJacContinuous(
+void IMUIncrement::propagateCovarianceAndBiasJacobian(
     double dt, const Eigen::Vector3d &omega, const Eigen::Vector3d &accel) {
   // Compute continuous-time A matrix
-  Eigen::Matrix3d C;
-  Eigen::Vector3d v;
-  Eigen::Vector3d r;
-  SE23::toComponents(delta_U, C, v, r);
+  Eigen::Matrix3d C = delta_U.block<3, 3>(0, 0);
+  Eigen::Vector3d v = delta_U.block<3, 1>(0, 3);
+  Eigen::Vector3d r = delta_U.block<3, 1>(0, 4);
 
+  // Compute the continuous-time A and L matrices based on the
+  // state representation and direction
   Eigen::Matrix<double, 15, 15> A_ct = Eigen::Matrix<double, 15, 15>::Zero();
   Eigen::Matrix<double, 15, 12> L_ct = Eigen::Matrix<double, 15, 12>::Zero();
+  if (pose_rep == ExtendedPoseRepresentation::SE23) {
+    computeContinuousTimeJacobiansSE23(C, v, r, omega, accel, A_ct, L_ct);
+  } else if (pose_rep == ExtendedPoseRepresentation::Decoupled) {
+    computeContinuousTimeJacobiansDecoupled(C, v, r, omega, accel, A_ct, L_ct);
+    LOG(WARNING) << "Decoupled representation is not fully implemented yet. "
+                 << "Using SE23 representation for now.";
+  } else {
+    LOG(FATAL) << "Unknown pose representation: " << static_cast<int>(pose_rep);
+  }
+
+  Eigen::MatrixXd A_d, Q_d;
+  discretizeSystem(A_ct, L_ct, Q_ct, dt, A_d, Q_d,
+                   DiscretizationMethod::TaylorSeries);
+  Q_d = 0.5 * (Q_d + Q_d.transpose());
+
+  // Propagate Jacobian forward and extract bias portion
+  jacobian = A_d * jacobian;
+  bias_jacobian = jacobian.block<9, 6>(0, 9);
+
+  // Propagate covariance forward
+  covariance = A_d * covariance * A_d.transpose() + Q_d;
+}
+
+void IMUIncrement::symmetrize() {
+  covariance = 0.5 * (covariance + covariance.transpose());
+}
+
+void IMUIncrement::computeContinuousTimeJacobiansDecoupled(
+    const Eigen::Matrix3d &C, const Eigen::Vector3d &v,
+    const Eigen::Vector3d &r, const Eigen::Vector3d &omega,
+    const Eigen::Vector3d &accel, Eigen::Matrix<double, 15, 15> &A_ct,
+    Eigen::Matrix<double, 15, 12> &L_ct) {
+  A_ct.setZero();
+  L_ct.setZero();
+
+  if (direction == LieDirection::left) {
+    LOG(INFO) << "Left lie direction for decoupled navigation state "
+                 "representation not yet supported!"; 
+  } else if (direction == LieDirection::right) {
+    Eigen::Vector3d unbiased_gyro = omega - gyro_bias;
+    Eigen::Vector3d unbiased_accel = accel - accel_bias;
+
+    A_ct.block<3, 3>(0, 0) = -SO3::cross(unbiased_gyro);
+    A_ct.block<3, 3>(0, 9) = -Eigen::Matrix3d::Identity();
+    A_ct.block<3, 3>(3, 0) = -C * SO3::cross(unbiased_accel);
+    A_ct.block<3, 3>(0, 9) = -C;
+    A_ct.block<3, 3>(6, 3) = Eigen::Matrix3d::Identity();
+
+    L_ct.block<3, 3>(0, 0) = Eigen::Matrix3d::Identity();
+    L_ct.block<3, 3>(3, 3) = C;
+    L_ct.block<3, 3>(9, 6) = Eigen::Matrix3d::Identity();
+    L_ct.block<3, 3>(12, 9) = Eigen::Matrix3d::Identity();
+  }
+}
+
+void IMUIncrement::computeContinuousTimeJacobiansSE23(
+    const Eigen::Matrix3d &C, const Eigen::Vector3d &v,
+    const Eigen::Vector3d &r, const Eigen::Vector3d &omega,
+    const Eigen::Vector3d &accel, Eigen::Matrix<double, 15, 15> &A_ct,
+    Eigen::Matrix<double, 15, 12> &L_ct) {
+  A_ct.setZero();
+  L_ct.setZero();
   if (direction == LieDirection::left) {
     A_ct.block<3, 3>(0, 9) = -C;
     A_ct.block<3, 3>(3, 9) = -SO3::cross(v) * C;
@@ -117,37 +176,6 @@ void IMUIncrement::propagateCovarianceAndBiasJacContinuous(
     L_ct.block<3, 3>(9, 6) = Eigen::Matrix3d::Identity();
     L_ct.block<3, 3>(12, 9) = Eigen::Matrix3d::Identity();
   }
-
-  // Discretize the system
-  Eigen::Matrix<double, 15, 15> A_dt = A_ct * dt;
-  Eigen::Matrix<double, 15, 15> A_dt_square = A_dt * A_dt;
-  Eigen::Matrix<double, 15, 15> A_dt_cube = A_dt_square * A_dt;
-  Eigen::Matrix<double, 15, 15> A_d =
-      Eigen::Matrix<double, 15, 15>::Identity() + A_dt + 0.5 * A_dt_square +
-      (1.0 / 6.0) * A_dt_cube;
-
-  // Get discrete-time noise
-  Eigen::Matrix<double, 15, 15> Q = L_ct * Q_ct * L_ct.transpose();
-  Eigen::Matrix<double, 15, 15> first_term = Q * dt;
-  Eigen::Matrix<double, 15, 15> second_term =
-      (A_ct * Q + Q * A_ct.transpose()) * (dt * dt) / 2.0;
-  Eigen::Matrix<double, 15, 15> third_term =
-      (A_ct * A_ct * Q + 2.0 * A_ct * Q * A_ct.transpose() +
-       Q * A_ct.transpose() * A_ct.transpose()) *
-      (dt * dt * dt) / 6.0;
-  Eigen::Matrix<double, 15, 15> Q_d = first_term + second_term + third_term;
-  Q_d = 0.5 * (Q_d + Q_d.transpose());
-
-  // Propagate Jacobian forward and extract bias portion
-  jacobian = A_d * jacobian;
-  bias_jacobian = jacobian.block<9, 6>(0, 9);
-
-  // Propagate covariance forward
-  covariance = A_d * covariance * A_d.transpose() + Q_d;
-}
-
-void IMUIncrement::symmetrize() {
-  covariance = 0.5 * (covariance + covariance.transpose());
 }
 
 void IMUIncrement::repropagate(const Eigen::Vector3d &init_gyro_bias,

--- a/src/imu/IMUPreintegrationHelper.cpp
+++ b/src/imu/IMUPreintegrationHelper.cpp
@@ -150,11 +150,13 @@ IMUPreintegrationHelper::computeRawJacobians(const IMUStateHolder &X_i,
     if (direction == LieDirection::left) {
       LOG(INFO) << "Left Jacobians not implemented for decoupled navigation "
                    "state representation.";
+      return std::vector<Eigen::Matrix<double, 15, 15>>();
     } else if (direction == LieDirection::right) {
       return computeRawJacobiansRightDecoupled(X_i, X_j);
     } else {
       LOG(INFO) << "Unknown Lie direction for decoupled navigation state "
                    "representation.";
+      return std::vector<Eigen::Matrix<double, 15, 15>>();
     }
   }
 }

--- a/src/imu/IMUPreintegrationHelper.cpp
+++ b/src/imu/IMUPreintegrationHelper.cpp
@@ -1,0 +1,363 @@
+#include "imu/IMUPreintegrationHelper.h"
+
+IMUPreintegrationHelper::IMUPreintegrationHelper(
+    const IMUIncrement &imu_increment, bool use_group_jacobians_,
+    const LieDirection &direction_, ExtendedPoseRepresentation pose_rep_)
+    : rmi{imu_increment}, use_group_jacobians{use_group_jacobians_},
+      direction{direction_}, pose_rep{pose_rep_} {}
+
+Eigen::Matrix<double, 15, 1>
+IMUPreintegrationHelper::computePreintegrationError(
+    const IMUStateHolder &X_i, const IMUStateHolder &X_j) const {
+  // Correct RMI for new value of bias
+  Eigen::Matrix<double, 5, 5> Y_meas = getUpdatedRMI(X_i);
+  // Get predicted RMI based on states and form the error
+  Eigen::Matrix<double, 5, 5> Y_pred = predictNavRMI(X_i, X_j);
+
+  // Compute the error on the navigation RMI
+  Eigen::Matrix<double, 9, 1> e_nav = Eigen::Matrix<double, 9, 1>::Zero();
+  if (pose_rep == ExtendedPoseRepresentation::SE23) {
+    // If we're using SE_2(3) representation, compute the error between the
+    // predicted and measured RMI on SE_2(3)
+    e_nav = SE23::minus(Y_pred, Y_meas, direction);
+  } else if (pose_rep == ExtendedPoseRepresentation::Decoupled) {
+    // Else, we compute the error using the decoupled representation
+    e_nav.block<3, 1>(0, 0) = SO3::minus(Y_pred.block<3, 3>(0, 0),
+                                         Y_meas.block<3, 3>(0, 0), direction);
+    e_nav.block<3, 1>(3, 0) =
+        Y_pred.block<3, 1>(0, 3) - Y_meas.block<3, 1>(0, 3);
+    e_nav.block<3, 1>(6, 0) =
+        Y_pred.block<3, 1>(0, 4) - Y_meas.block<3, 1>(0, 4);
+  }
+
+  Eigen::Vector3d e_bg = X_j.bias_gyro - X_i.bias_gyro;
+  Eigen::Vector3d e_ba = X_j.bias_accel - X_i.bias_accel;
+
+  Eigen::Matrix<double, 15, 1> error;
+  error.block<9, 1>(0, 0) = e_nav;
+  error.block<3, 1>(9, 0) = e_bg;
+  error.block<3, 1>(12, 0) = e_ba;
+  return error;
+}
+
+Eigen::Matrix<double, 5, 5>
+IMUPreintegrationHelper::getUpdatedRMI(const IMUStateHolder &X_i) const {
+  Eigen::Matrix<double, 6, 1> dbias;
+  Eigen::Vector3d d_bg = X_i.bias_gyro - rmi.gyro_bias;
+  Eigen::Vector3d d_ba = X_i.bias_accel - rmi.accel_bias;
+  dbias.block<3, 1>(0, 0) = d_bg;
+  dbias.block<3, 1>(3, 0) = d_ba;
+
+  Eigen::Matrix<double, 5, 5> delta_X = Eigen::Matrix<double, 5, 5>::Identity();
+  delta_X.block<3, 3>(0, 0) = rmi.delta_U.block<3, 3>(0, 0);
+  delta_X.block<3, 1>(0, 3) = rmi.delta_U.block<3, 1>(0, 3);
+  delta_X.block<3, 1>(0, 4) = rmi.delta_U.block<3, 1>(0, 4);
+
+  // If we're using an SE_2(3) representation, perform first-order
+  // bias correct directly on the group
+  if (pose_rep == ExtendedPoseRepresentation::SE23) {
+    if (direction == LieDirection::left) {
+      return SE23::expMap(rmi.bias_jacobian * dbias) * delta_X;
+    } else if (direction == LieDirection::right) {
+      return delta_X * SE23::expMap(rmi.bias_jacobian * dbias);
+    } else {
+      std::cout << "WARNING: Unknown Lie direction!" << std::endl;
+      return Eigen::Matrix<double, 5, 5>::Identity();
+    }
+  }
+
+  // Perform first-order bias correct for decoupled representation
+  // This corresponds to the scheme presented in "On-Manifold Preintegration for
+  // Real-Time "Visual–Inertial Odometry" by Forster et al. (2017). (see
+  // equation (44))
+  else if (pose_rep == ExtendedPoseRepresentation::Decoupled) {
+    // Extract subcomponents
+    Eigen::Matrix3d delta_C = delta_X.block<3, 3>(0, 0);
+    Eigen::Vector3d delta_v = delta_X.block<3, 1>(0, 3);
+    Eigen::Vector3d delta_r = delta_X.block<3, 1>(0, 4);
+
+    // Extract relevant parts of the bias Jacobian
+    Eigen::Matrix3d dC_dbg = rmi.bias_jacobian.block<3, 3>(0, 0);
+
+    Eigen::Matrix<double, 3, 6> dv_db = rmi.bias_jacobian.block<3, 6>(3, 0);
+    Eigen::Matrix<double, 3, 6> dr_db = rmi.bias_jacobian.block<3, 6>(6, 0);
+
+    Eigen::Vector3d delta_v_updated = delta_v + dv_db * dbias;
+    Eigen::Vector3d delta_r_updated = delta_r + dr_db * dbias;
+
+    Eigen::Matrix3d delta_C_updated;
+    // Update delta_C with the correct perturbation
+    if (direction == LieDirection::left) {
+      delta_C_updated = SO3::expMap(dC_dbg * d_bg) * delta_C;
+    } else if (direction == LieDirection::right) {
+      // Perform first-order correction
+      delta_C_updated = delta_C * SO3::expMap(dC_dbg * d_bg);
+    }
+    // Assemble the updated delta_X matrix
+    Eigen::Matrix<double, 5, 5> delta_X_updated =
+        Eigen::Matrix<double, 5, 5>::Identity();
+    delta_X_updated.block<3, 3>(0, 0) = delta_C_updated;
+    delta_X_updated.block<3, 1>(0, 3) = delta_v_updated;
+    delta_X_updated.block<3, 1>(0, 4) = delta_r_updated;
+    return delta_X_updated;
+  } else {
+    LOG(ERROR) << "Unknown ExtendedPoseRepresentation type!";
+    return Eigen::Matrix<double, 5, 5>::Identity();
+  }
+}
+
+Eigen::Matrix<double, 5, 5>
+IMUPreintegrationHelper::predictNavRMI(const IMUStateHolder &X_i,
+                                       const IMUStateHolder &X_j) const {
+  Eigen::Vector3d g_a = rmi.gravity;
+  Eigen::Matrix3d C_i = X_i.attitude;
+  Eigen::Vector3d v_i = X_i.velocity;
+  Eigen::Vector3d r_i = X_i.position;
+
+  Eigen::Matrix3d C_j = X_j.attitude;
+  Eigen::Vector3d v_j = X_j.velocity;
+  Eigen::Vector3d r_j = X_j.position;
+
+  double delta_t = rmi.end_stamp - rmi.start_stamp;
+  Eigen::Matrix3d delta_C = C_i.transpose() * C_j;
+  Eigen::Vector3d delta_v = C_i.transpose() * (v_j - v_i - g_a * delta_t);
+  Eigen::Vector3d delta_r = C_i.transpose() * (r_j - r_i - v_i * delta_t -
+                                               0.5 * g_a * (delta_t * delta_t));
+
+  Eigen::Matrix<double, 5, 5> delta_X_nav =
+      SE23::fromComponents(delta_C, delta_v, delta_r);
+  return delta_X_nav;
+}
+
+std::vector<Eigen::Matrix<double, 15, 15>>
+IMUPreintegrationHelper::computeRawJacobians(const IMUStateHolder &X_i,
+                                             const IMUStateHolder &X_j) const {
+  if (pose_rep == ExtendedPoseRepresentation::SE23) {
+    if (direction == LieDirection::left) {
+      return computeRawJacobiansLeftSE23(X_i, X_j);
+    } else if (direction == LieDirection::right) {
+      return computeRawJacobiansRightSE23(X_i, X_j);
+    } else {
+      std::cout << "WARNING: Unknown Lie direction!" << std::endl;
+      return std::vector<Eigen::Matrix<double, 15, 15>>();
+    }
+  } else if (pose_rep == ExtendedPoseRepresentation::Decoupled) {
+    if (direction == LieDirection::left) {
+      LOG(INFO) << "Left Jacobians not implemented for decoupled navigation "
+                   "state representation.";
+    } else if (direction == LieDirection::right) {
+      return computeRawJacobiansRightDecoupled(X_i, X_j);
+    } else {
+      LOG(INFO) << "Unknown Lie direction for decoupled navigation state "
+                   "representation.";
+    }
+  }
+}
+
+std::vector<Eigen::Matrix<double, 15, 15>>
+IMUPreintegrationHelper::computeRawJacobiansLeftSE23(
+    const IMUStateHolder &X_i, const IMUStateHolder &X_j) const {
+  // Extract individual states
+  Eigen::Vector3d g_a = rmi.gravity;
+  Eigen::Matrix3d C_i = X_i.attitude;
+  Eigen::Vector3d v_i = X_i.velocity;
+  Eigen::Vector3d r_i = X_i.position;
+  Eigen::Vector3d ba_i = X_i.bias_accel;
+
+  Eigen::Vector3d v_j = X_j.velocity;
+  Eigen::Vector3d r_j = X_j.position;
+
+  Eigen::Matrix<double, 5, 5> del_Xy_mat = getUpdatedRMI(X_i);
+  Eigen::Matrix<double, 5, 5> del_Xx_mat = predictNavRMI(X_i, X_j);
+
+  // Extract required subcomponents of matrix
+  Eigen::Matrix<double, 3, 1> del_Xx_v = del_Xx_mat.block<3, 1>(0, 3);
+  Eigen::Matrix<double, 3, 1> del_Xx_r = del_Xx_mat.block<3, 1>(0, 4);
+  double delta_t = rmi.end_stamp - rmi.start_stamp;
+
+  // Jacobian of \Delta X^X with respect to X_i
+  Eigen::Matrix<double, 15, 15> D_delta_xx_Xi =
+      Eigen::Matrix<double, 15, 15>::Zero();
+  D_delta_xx_Xi.block<3, 3>(0, 0) = -C_i.transpose();
+  D_delta_xx_Xi.block<3, 3>(3, 0) = C_i.transpose() * SO3::cross(v_i);
+  D_delta_xx_Xi.block<3, 3>(3, 3) = -C_i.transpose();
+  D_delta_xx_Xi.block<3, 3>(6, 0) =
+      C_i.transpose() * SO3::cross(r_i + v_i * delta_t);
+  D_delta_xx_Xi.block<3, 3>(6, 3) = -delta_t * C_i.transpose();
+  D_delta_xx_Xi.block<3, 3>(6, 6) = -C_i.transpose();
+  D_delta_xx_Xi.block<6, 6>(9, 9) = -Eigen::Matrix<double, 6, 6>::Identity();
+
+  // Compute Jacobian of error w.r.t del_Xy
+  Eigen::Matrix<double, 6, 1> dbias;
+  dbias.block<3, 1>(0, 0) = X_i.bias_gyro - rmi.gyro_bias;
+  dbias.block<3, 1>(3, 0) = X_i.bias_accel - rmi.accel_bias;
+  Eigen::Matrix<double, 9, 6> bias_jac = rmi.bias_jacobian;
+  Eigen::Matrix<double, 9, 1> tau = bias_jac * dbias;
+
+  Eigen::Matrix<double, 9, 6> Ji_X_b =
+      SE23::leftJacobian(bias_jac * dbias) * bias_jac;
+  Eigen::Matrix<double, 15, 15> xi_i_y = Eigen::Matrix<double, 15, 15>::Zero();
+  xi_i_y.block<9, 6>(0, 9) = Ji_X_b;
+
+  // If we want to include the group jacobians, need to compute
+  // the Jacobian of the error with respect to the delta_X^Y
+  // and delta_X^X
+  Eigen::Matrix<double, 15, 15> De_D_delta_xy =
+      -Eigen::Matrix<double, 15, 15>::Identity();
+  Eigen::Matrix<double, 15, 15> De_D_delta_xx =
+      Eigen::Matrix<double, 15, 15>::Identity();
+
+  if (use_group_jacobians) {
+    Eigen::Matrix<double, 15, 1> error = computePreintegrationError(X_i, X_j);
+    Eigen::Matrix<double, 9, 1> e_nav = error.block<9, 1>(0, 0);
+
+    De_D_delta_xx.block<9, 9>(0, 0) = SE23::leftJacobianInverse(e_nav);
+    De_D_delta_xy.block<9, 9>(0, 0) = -SE23::rightJacobianInverse(e_nav);
+  }
+
+  Eigen::Matrix<double, 15, 15> jac_i =
+      De_D_delta_xy * xi_i_y + De_D_delta_xx * D_delta_xx_Xi;
+
+  // Compute Jacobians of error w.r.t X_j
+  Eigen::Matrix3d Jj_C_C = C_i.transpose();
+  Eigen::Matrix3d Jj_v_C = -C_i.transpose() * SO3::cross(v_j) +
+                           SO3::cross(del_Xx_v) * C_i.transpose();
+  Eigen::Matrix3d Jj_v_v = C_i.transpose();
+  Eigen::Matrix3d Jj_r_C = -C_i.transpose() * SO3::cross(r_j) +
+                           SO3::cross(del_Xx_r) * C_i.transpose();
+  Eigen::Matrix3d Jj_r_r = C_i.transpose();
+  // Jacobian of \Delta X^X with respect to X_j
+  Eigen::Matrix<double, 15, 15> xi_j_x = Eigen::Matrix<double, 15, 15>::Zero();
+  xi_j_x.block<3, 3>(0, 0) = Jj_C_C;
+  xi_j_x.block<3, 3>(3, 0) = Jj_v_C;
+  xi_j_x.block<3, 3>(3, 3) = Jj_v_v;
+  xi_j_x.block<3, 3>(6, 0) = Jj_r_C;
+  xi_j_x.block<3, 3>(6, 6) = Jj_r_r;
+  xi_j_x.block<6, 6>(9, 9) = Eigen::Matrix<double, 6, 6>::Identity();
+  Eigen::Matrix<double, 15, 15> jac_j = De_D_delta_xx * xi_j_x;
+
+  std::vector<Eigen::Matrix<double, 15, 15>> raw_jacobians;
+  raw_jacobians.push_back(jac_i);
+  raw_jacobians.push_back(jac_j);
+  return raw_jacobians;
+}
+
+std::vector<Eigen::Matrix<double, 15, 15>>
+IMUPreintegrationHelper::computeRawJacobiansRightSE23(
+    const IMUStateHolder &X_i, const IMUStateHolder &X_j) const {
+  Eigen::Matrix<double, 5, 5> del_Xx_mat = predictNavRMI(X_i, X_j);
+
+  // Extract required subcomponents of matrix
+  Eigen::Matrix3d del_Xx_C = del_Xx_mat.block<3, 3>(0, 0);
+  Eigen::Vector3d del_Xx_v = del_Xx_mat.block<3, 1>(0, 3);
+  Eigen::Vector3d del_Xx_r = del_Xx_mat.block<3, 1>(0, 4);
+  double delta_t = rmi.end_stamp - rmi.start_stamp;
+
+  // Compute Jacobian of \Delta_X^X with respect to X_i
+  Eigen::Matrix<double, 15, 15> xi_i_x = Eigen::Matrix<double, 15, 15>::Zero();
+  xi_i_x.block<3, 3>(0, 0) = -del_Xx_C.transpose();
+  xi_i_x.block<3, 3>(3, 0) = del_Xx_C.transpose() * SO3::cross(del_Xx_v);
+  xi_i_x.block<3, 3>(3, 3) = -del_Xx_C.transpose();
+  xi_i_x.block<3, 3>(6, 0) = del_Xx_C.transpose() * SO3::cross(del_Xx_r);
+  xi_i_x.block<3, 3>(6, 3) = -delta_t * del_Xx_C.transpose();
+  xi_i_x.block<3, 3>(6, 6) = -del_Xx_C.transpose();
+  xi_i_x.block<6, 6>(9, 9) = -Eigen::Matrix<double, 6, 6>::Identity();
+
+  // Compute Jacobian of error with respect to \Delta X^Y
+  Eigen::Matrix<double, 6, 1> dbias;
+  dbias.block<3, 1>(0, 0) = X_i.bias_gyro - rmi.gyro_bias;
+  dbias.block<3, 1>(3, 0) = X_i.bias_accel - rmi.accel_bias;
+  Eigen::Matrix<double, 9, 6> bias_jac = rmi.bias_jacobian;
+  Eigen::Matrix<double, 9, 1> tau = bias_jac * dbias;
+  Eigen::Matrix<double, 9, 6> Ji_X_b = SE23::rightJacobian(tau) * bias_jac;
+
+  Eigen::Matrix<double, 15, 15> xi_i_y = Eigen::Matrix<double, 15, 15>::Zero();
+  xi_i_y.block<9, 6>(0, 9) = Ji_X_b;
+
+  // Jacobian of \Delta X^X with respect to X_j
+  Eigen::Matrix<double, 15, 15> jac_j =
+      Eigen::Matrix<double, 15, 15>::Identity();
+
+  Eigen::Matrix<double, 15, 15> De_D_delta_xy =
+      -Eigen::Matrix<double, 15, 15>::Identity();
+  Eigen::Matrix<double, 15, 15> De_D_delta_xx =
+      Eigen::Matrix<double, 15, 15>::Identity();
+
+  if (use_group_jacobians) {
+    Eigen::Matrix<double, 15, 1> error = computePreintegrationError(X_i, X_j);
+    Eigen::Matrix<double, 9, 1> e_nav = error.block<9, 1>(0, 0);
+    De_D_delta_xy.block<9, 9>(0, 0) = -SE23::leftJacobianInverse(e_nav);
+    De_D_delta_xx.block<9, 9>(0, 0) = SE23::rightJacobianInverse(e_nav);
+  }
+
+  Eigen::Matrix<double, 15, 15> jac_i =
+      De_D_delta_xy * xi_i_y + De_D_delta_xx * xi_i_x;
+  jac_j = De_D_delta_xx * jac_j;
+
+  std::vector<Eigen::Matrix<double, 15, 15>> raw_jacobians;
+  raw_jacobians.push_back(jac_i);
+  raw_jacobians.push_back(jac_j);
+  return raw_jacobians;
+}
+
+std::vector<Eigen::Matrix<double, 15, 15>>
+IMUPreintegrationHelper::computeRawJacobiansRightDecoupled(
+    const IMUStateHolder &X_i, const IMUStateHolder &X_j) const {
+  Eigen::Matrix<double, 5, 5> del_Xx_mat = predictNavRMI(X_i, X_j);
+
+  // Extract required subcomponents of matrix
+  Eigen::Matrix3d del_Xx_C = del_Xx_mat.block<3, 3>(0, 0);
+  Eigen::Vector3d del_Xx_v = del_Xx_mat.block<3, 1>(0, 3);
+  Eigen::Vector3d del_Xx_r = del_Xx_mat.block<3, 1>(0, 4);
+  double delta_t = rmi.end_stamp - rmi.start_stamp;
+
+  Eigen::Matrix3d C_i = X_i.attitude;
+
+  // Compute Jacobian of \Delta_X^X with respect to X_i
+  Eigen::Matrix<double, 15, 15> D_delta_xx_Xi =
+      Eigen::Matrix<double, 15, 15>::Zero();
+  D_delta_xx_Xi.block<3, 3>(0, 0) = -del_Xx_C.transpose();
+  D_delta_xx_Xi.block<3, 3>(3, 0) = SO3::cross(del_Xx_v);
+  D_delta_xx_Xi.block<3, 3>(3, 3) = -C_i.transpose();
+  D_delta_xx_Xi.block<3, 3>(6, 0) = SO3::cross(del_Xx_r);
+  D_delta_xx_Xi.block<3, 3>(6, 3) = -delta_t * C_i.transpose();
+  D_delta_xx_Xi.block<3, 3>(6, 6) = -C_i.transpose();
+  D_delta_xx_Xi.block<6, 6>(9, 9) = -Eigen::Matrix<double, 6, 6>::Identity();
+
+  // Compute Jacobian of \Delta_X^Y with respect to X_i
+  // We need the bias Jacobian here
+  Eigen::Matrix<double, 9, 6> bias_jac = rmi.bias_jacobian;
+
+  Eigen::Matrix<double, 15, 15> D_delta_xy_Xi =
+      Eigen::Matrix<double, 15, 15>::Zero();
+  D_delta_xy_Xi.block<9, 6>(0, 9) = bias_jac;
+
+  // Compute Jacobian of \Delta X^X with respect to X_j
+  Eigen::Matrix<double, 15, 15> D_delta_xx_Xj =
+      Eigen::Matrix<double, 15, 15>::Identity();
+  D_delta_xx_Xj.block<3, 3>(3, 3) = C_i.transpose();
+  D_delta_xx_Xj.block<3, 3>(6, 6) = C_i.transpose();
+
+  // Group Jacobians
+  Eigen::Matrix<double, 15, 15> De_D_delta_xy =
+      -Eigen::Matrix<double, 15, 15>::Identity();
+  Eigen::Matrix<double, 15, 15> De_D_delta_xx =
+      Eigen::Matrix<double, 15, 15>::Identity();
+
+  if (use_group_jacobians) {
+    Eigen::Matrix<double, 15, 1> error = computePreintegrationError(X_i, X_j);
+    Eigen::Matrix<double, 3, 1> e_att = error.block<3, 1>(0, 0);
+
+    De_D_delta_xx.block<3, 3>(0, 0) = SO3::rightJacobianInverse(e_att);
+    De_D_delta_xy.block<3, 3>(0, 0) = -SO3::leftJacobianInverse(e_att);
+  }
+
+  Eigen::Matrix<double, 15, 15> jac_i =
+      De_D_delta_xx * D_delta_xx_Xi + De_D_delta_xy * D_delta_xy_Xi;
+  Eigen::Matrix<double, 15, 15> jac_j = De_D_delta_xx * D_delta_xx_Xj;
+
+  std::vector<Eigen::Matrix<double, 15, 15>> raw_jacobians;
+  raw_jacobians.push_back(jac_i);
+  raw_jacobians.push_back(jac_j);
+  return raw_jacobians;
+}

--- a/src/lie/SE23.cpp
+++ b/src/lie/SE23.cpp
@@ -22,7 +22,7 @@ Eigen::Matrix<double, 9, 1> SE23::logMap(const Eigen::MatrixXd &X) {
   SE23::toComponents(X, C, v, r);
 
   Eigen::Vector3d phi = SO3::logMap(C);
-  Eigen::Matrix3d J_left_inv = SO3::leftJacobianInv(phi);
+  Eigen::Matrix3d J_left_inv = SO3::leftJacobianInverse(phi);
 
   Eigen::Matrix<double, 9, 1> xi;
   xi.block<3, 1>(0, 0) = phi;
@@ -120,7 +120,7 @@ SE23::leftJacobianInverse(const Eigen::VectorXd &x) {
   } else {
     Eigen::Vector3d xi_v{x.block<3, 1>(3, 0)};
     Eigen::Vector3d xi_r{x.block<3, 1>(6, 0)};
-    Eigen::Matrix3d Jinv{SO3::leftJacobianInv(x.block<3, 1>(0, 0))};
+    Eigen::Matrix3d Jinv{SO3::leftJacobianInverse(x.block<3, 1>(0, 0))};
     Eigen::Matrix3d Q_v{leftJacobianQMatrix(phi, xi_v)};
     Eigen::Matrix3d Q_r{leftJacobianQMatrix(phi, xi_r)};
 

--- a/src/lie/SE3.cpp
+++ b/src/lie/SE3.cpp
@@ -29,7 +29,7 @@ Eigen::Matrix<double, 6, 1> SE3::logMap(const Eigen::MatrixXd &X) {
   SE3::toComponents(X, C, r);
 
   Eigen::Vector3d phi = SO3::logMap(C);
-  Eigen::Matrix3d J_left_inv = SO3::leftJacobianInv(phi);
+  Eigen::Matrix3d J_left_inv = SO3::leftJacobianInverse(phi);
 
   Eigen::Matrix<double, 6, 1> xi;
   xi.block<3, 1>(0, 0) = phi;
@@ -97,7 +97,7 @@ Eigen::Matrix<double, 6, 6> SE3::leftJacobianInverse(const Eigen::VectorXd &x)
       return Eigen::Matrix<double, 6, 6>::Identity();
     } else {
       Eigen::Matrix<double, 6, 6> J = Eigen::Matrix<double, 6, 6>::Zero();
-      Eigen::Matrix3d Jinv{SO3::leftJacobianInv(x.block<3, 1>(0, 0))};
+      Eigen::Matrix3d Jinv{SO3::leftJacobianInverse(x.block<3, 1>(0, 0))};
       Eigen::Matrix3d Q{
           SE3::leftJacobianQMatrix(x.block<3, 1>(0, 0), x.block<3, 1>(3, 0))};
       J.block<3, 3>(0, 0) = Jinv;

--- a/src/lie/SO3.cpp
+++ b/src/lie/SO3.cpp
@@ -123,7 +123,7 @@ Eigen::Matrix3d SO3::leftJacobian(const Eigen::Vector3d &phi) {
  * the paper by Joan Sola is numerically equivalent to the form implemented
  * here.
  */
-Eigen::Matrix3d SO3::leftJacobianInv(const Eigen::Vector3d &phi) {
+Eigen::Matrix3d SO3::leftJacobianInverse(const Eigen::Vector3d &phi) {
   double angle = phi.norm();
   double A;
 
@@ -153,7 +153,7 @@ Eigen::Matrix3d SO3::leftJacobianInv(const Eigen::Vector3d &phi) {
  * section 7.1.5 of "State Estimation for Robotics" by T. Barfoot is used,
  * which says that J^r (phi) = J^left (-phi).
  */
-Eigen::Matrix3d SO3::computeJRight(const Eigen::Vector3d &phi) {
+Eigen::Matrix3d SO3::rightJacobian(const Eigen::Vector3d &phi) {
   // Equation (7.87) of "State Estimation for Robotics".
   return SO3::leftJacobian(-phi);
 }
@@ -163,8 +163,8 @@ Eigen::Matrix3d SO3::computeJRight(const Eigen::Vector3d &phi) {
  * The relationship between the left and right inverse JAcobians is once again
  * used.
  */
-Eigen::Matrix3d SO3::computeJRightInv(const Eigen::Vector3d &phi) {
-  return SO3::leftJacobianInv(-phi);
+Eigen::Matrix3d SO3::rightJacobianInverse(const Eigen::Vector3d &phi) {
+  return SO3::leftJacobianInverse(-phi);
 }
 
 Eigen::Vector3d SO3::toEuler(const Eigen::Matrix3d &C) {

--- a/src/local_parameterizations/DecoupledExtendedPoseLocalParameterization.cpp
+++ b/src/local_parameterizations/DecoupledExtendedPoseLocalParameterization.cpp
@@ -1,0 +1,45 @@
+#include "local_parameterizations/DecoupledExtendedPoseLocalParameterization.h"
+#include "lie/SE23.h"
+#include "lie/SO3.h"
+
+/**
+ * ExtendedPoseLocalParameterization::Plus defines the update rule for elements
+ * of SE_2(3). This function defines how to increment parameters x, given a
+ * small increment delta. The size of x is the GlobalSize of the parameter block
+ * (10), while the size of delta is the LocalSize of the parameter block (9).
+ * The variable x_plus_delta encodes how the global parameterization changes due
+ * to an increment delta and it's size is the GlobalSize.
+ */
+bool DecoupledExtendedPoseLocalParameterization::Plus(
+    const double *x, const double *delta, double *x_plus_delta) const {
+  Eigen::Map<const Eigen::Matrix<double, 9, 1>> delta_xi_raw(delta); // SE23
+  Eigen::Map<Eigen::Matrix<double, 15, 1>> x_plus_delta_raw(
+      x_plus_delta); // Ceres
+
+  Eigen::Matrix<double, 5, 5> X = SE23::fromCeresParameters(x);
+
+  // Update the state
+  Eigen::Matrix3d C_new;
+  Eigen::Vector3d v_new;
+  Eigen::Vector3d r_new;
+
+  // Update the DCM with the correct perturbation
+  if (_direction == LieDirection::left) {
+    C_new = SO3::expMap(delta_xi_raw.block<3, 1>(0, 0)) * X.block<3, 3>(0, 0);
+  }
+  else if (_direction == LieDirection::right) {
+    C_new = X.block<3, 3>(0, 0) * SO3::expMap(delta_xi_raw.block<3, 1>(0, 0));
+  } else {
+    std::cerr << "Invalid Lie direction" << std::endl;
+  }
+
+  // Update the velocity and position
+  v_new = X.block<3, 1>(0, 3) + delta_xi_raw.block<3, 1>(3, 0);
+  r_new = X.block<3, 1>(0, 4) + delta_xi_raw.block<3, 1>(6, 0);
+
+  // Return the updated state
+  x_plus_delta_raw.block<9, 1>(0, 0) = SO3::flatten(C_new);
+  x_plus_delta_raw.block<3, 1>(9, 0) = v_new;
+  x_plus_delta_raw.block<3, 1>(12, 0) = r_new;
+  return true;
+}

--- a/src/local_parameterizations/ExtendedPoseLocalParameterization.cpp
+++ b/src/local_parameterizations/ExtendedPoseLocalParameterization.cpp
@@ -1,45 +1,4 @@
 #include "local_parameterizations/ExtendedPoseLocalParameterization.h"
-#include "lie/SE23.h"
-#include "lie/SO3.h"
-
-/**
- * ExtendedPoseLocalParameterization::Plus defines the update rule for elements
- * of SE_2(3). This function defines how to increment parameters x, given a
- * small increment delta. The size of x is the GlobalSize of the parameter block
- * (10), while the size of delta is the LocalSize of the parameter block (9).
- * The variable x_plus_delta encodes how the global parameterization changes due
- * to an increment delta and it's size is the GlobalSize.
- */
-bool ExtendedPoseLocalParameterization::Plus(const double *x,
-                                             const double *delta,
-                                             double *x_plus_delta) const {
-  Eigen::Map<const Eigen::Matrix<double, 9, 1>> delta_xi_raw(delta); // SE23
-  Eigen::Map<Eigen::Matrix<double, 15, 1>> x_plus_delta_raw(
-      x_plus_delta); // Ceres
-
-  Eigen::Matrix<double, 5, 5> X = SE23::fromCeresParameters(x);
-
-  // Update the state
-  Eigen::Matrix<double, 5, 5> X_new;
-  if (_direction == LieDirection::left){
-    X_new = SE23::expMap(delta_xi_raw) * X;
-  } else if (_direction == LieDirection::right){
-    X_new = X * SE23::expMap(delta_xi_raw);
-  } else {
-    std::cerr << "Invalid Lie direction" << std::endl;
-  }
-  Eigen::Matrix3d C_new;
-  Eigen::Vector3d v_new;
-  Eigen::Vector3d r_new;
-  SE23::toComponents(X_new, C_new, v_new, r_new);
-
-  //  Store updated result
-  x_plus_delta_raw.block<9, 1>(0, 0) = SO3::flatten(C_new);
-  x_plus_delta_raw.block<3, 1>(9, 0) = v_new;
-  x_plus_delta_raw.block<3, 1>(12, 0) = r_new;
-
-  return true;
-}
 
 /*
  * This function computes the Jacobian of the global parameterization w.r.t the
@@ -49,7 +8,6 @@ bool ExtendedPoseLocalParameterization::Plus(const double *x,
  * Jacobian of the residual with respect to the local parameterization.
  *
  */
-//
 bool ExtendedPoseLocalParameterization::ComputeJacobian(
     const double *x, double *jacobian) const {
   Eigen::Map<Eigen::Matrix<double, 15, 9, Eigen::RowMajor>> j(jacobian);

--- a/src/local_parameterizations/SE23LocalParameterization.cpp
+++ b/src/local_parameterizations/SE23LocalParameterization.cpp
@@ -1,0 +1,41 @@
+#include "local_parameterizations/SE23LocalParameterization.h"
+#include "lie/SE23.h"
+#include "lie/SO3.h"
+
+/**
+ * ExtendedPoseLocalParameterization::Plus defines the update rule for elements
+ * of SE_2(3). This function defines how to increment parameters x, given a
+ * small increment delta. The size of x is the GlobalSize of the parameter block
+ * (10), while the size of delta is the LocalSize of the parameter block (9).
+ * The variable x_plus_delta encodes how the global parameterization changes due
+ * to an increment delta and it's size is the GlobalSize.
+ */
+bool SE23LocalParameterization::Plus(const double *x, const double *delta,
+                                     double *x_plus_delta) const {
+  Eigen::Map<const Eigen::Matrix<double, 9, 1>> delta_xi_raw(delta); // SE23
+  Eigen::Map<Eigen::Matrix<double, 15, 1>> x_plus_delta_raw(
+      x_plus_delta); // Ceres
+
+  Eigen::Matrix<double, 5, 5> X = SE23::fromCeresParameters(x);
+
+  // Update the state
+  Eigen::Matrix<double, 5, 5> X_new;
+  if (_direction == LieDirection::left) {
+    X_new = SE23::expMap(delta_xi_raw) * X;
+  } else if (_direction == LieDirection::right) {
+    X_new = X * SE23::expMap(delta_xi_raw);
+  } else {
+    std::cerr << "Invalid Lie direction" << std::endl;
+  }
+  Eigen::Matrix3d C_new;
+  Eigen::Vector3d v_new;
+  Eigen::Vector3d r_new;
+  SE23::toComponents(X_new, C_new, v_new, r_new);
+
+  //  Store updated result
+  x_plus_delta_raw.block<9, 1>(0, 0) = SO3::flatten(C_new);
+  x_plus_delta_raw.block<3, 1>(9, 0) = v_new;
+  x_plus_delta_raw.block<3, 1>(12, 0) = r_new;
+
+  return true;
+}

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -1,13 +1,14 @@
 #include "utils/Utils.h"
 #include <fstream>
 
+
+namespace ceres_nav {
+
 double roundTo(double value, double precision) {
   return std::round(value / precision) * precision;
 }
 
 double roundStamp(double value) { return roundTo(value, 1e-3); }
-
-namespace ceres_nav {
 
 Eigen::MatrixXd
 computeSquareRootInformation(const Eigen::MatrixXd &covariance) {

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -7,6 +7,8 @@ double roundTo(double value, double precision) {
 
 double roundStamp(double value) { return roundTo(value, 1e-3); }
 
+namespace ceres_nav {
+
 Eigen::MatrixXd
 computeSquareRootInformation(const Eigen::MatrixXd &covariance) {
   // Check that we have a valid covariance that we can get the information of
@@ -73,7 +75,7 @@ void discretizeSystem(const Eigen::MatrixXd &A_ct, const Eigen::MatrixXd &L_ct,
         0.5 * A_dt_square + (1.0 / 6.0) * A_dt_cube;
 
   // Compute the discrete-time noise covariance
-  if (method == DiscretizationMethod::TaylorSeries) {
+  if (method == ceres_nav::DiscretizationMethod::TaylorSeries) {
     Eigen::Matrix<double, 15, 15> Q = L_ct * Q_ct * L_ct.transpose();
     Eigen::Matrix<double, 15, 15> first_term = Q * dt;
     Eigen::Matrix<double, 15, 15> second_term =
@@ -88,3 +90,5 @@ void discretizeSystem(const Eigen::MatrixXd &A_ct, const Eigen::MatrixXd &L_ct,
     throw std::invalid_argument("Unsupported discretization method");
   }
 }
+
+} // namespace ceres_nav

--- a/tests/test_jacobians.cpp
+++ b/tests/test_jacobians.cpp
@@ -22,6 +22,7 @@
 #include "lie/SE23.h"
 #include "lie/SO3.h"
 
+#include "lib/ExtendedPoseParameterBlock.h"
 #include "utils/CostFunctionUtils.h"
 
 TEST_CASE("Test AbsolutePositionFactor Jacobians") {
@@ -35,52 +36,63 @@ TEST_CASE("Test AbsolutePositionFactor Jacobians") {
   std::vector<LieDirection> directions = {LieDirection::left,
                                           LieDirection::right};
 
-  for (auto const &direction : directions) {
-    std::cout << "Testing AbsolutePositionFactor with direction: "
-              << (direction == LieDirection::left ? "left" : "right")
-              << std::endl;
+  std::vector<ExtendedPoseRepresentation> pose_types = {
+      ExtendedPoseRepresentation::SE23, ExtendedPoseRepresentation::Decoupled};
 
-    std::shared_ptr<AbsolutePositionFactor> factor =
-        std::make_shared<AbsolutePositionFactor>(measurement, direction,
-                                                 sqrt_info, "SE3", false);
-    REQUIRE(factor->num_residuals() == 3);
+  // Loop through each combination of pose type and Lie direction
+  for (auto const &pose_type : pose_types) {
+    for (auto const &direction : directions) {
+      std::cout << "Testing AbsolutePositionFactor with direction: "
+                << (direction == LieDirection::left ? "left" : "right")
+                << std::endl;
+      std::cout << "Pose type: "
+                << (pose_type == ExtendedPoseRepresentation::SE23 ? "SE23"
+                                                                  : "Decoupled")
+                << std::endl;
+      std::shared_ptr<AbsolutePositionFactor> factor =
+          std::make_shared<AbsolutePositionFactor>(measurement, direction,
+                                                   sqrt_info, false, pose_type);
+      REQUIRE(factor->num_residuals() == 3);
 
-    // Evaluate the factor with a pose parameter block
-    std::shared_ptr<PoseParameterBlock> pose_block =
-        std::make_shared<PoseParameterBlock>("test_pose", direction);
-    pose_block->setFromAttitudeAndPosition(attitude, position);
+      // Evaluate the factor with an ExtendedPoseParameterBlock
+      std::shared_ptr<ExtendedPoseParameterBlock> pose_block =
+          std::make_shared<ExtendedPoseParameterBlock>(pose_type, "test_pose",
+                                                       direction);
+      pose_block->setFromComponents(attitude, Eigen::Vector3d::Zero(),
+                                    position);
 
-    std::vector<std::shared_ptr<ParameterBlockBase>> parameter_blocks;
-    parameter_blocks.push_back(pose_block);
+      std::vector<std::shared_ptr<ParameterBlockBase>> parameter_blocks;
+      parameter_blocks.push_back(pose_block);
 
-    Eigen::VectorXd residuals(factor->num_residuals());
-    std::vector<Eigen::MatrixXd> jacobians;
+      Eigen::VectorXd residuals(factor->num_residuals());
+      std::vector<Eigen::MatrixXd> jacobians;
 
-    bool success = ceres_nav::evaluateCostFunction(factor, parameter_blocks,
-                                                   residuals, jacobians);
-    REQUIRE(success);
-    // Check the residuals
-    Eigen::Vector3d expected_residual = measurement - position;
-    REQUIRE(residuals.isApprox(expected_residual, 1e-6));
+      bool success = ceres_nav::evaluateCostFunction(factor, parameter_blocks,
+                                                     residuals, jacobians);
+      REQUIRE(success);
+      // Check the residuals
+      Eigen::Vector3d expected_residual = measurement - position;
+      REQUIRE(residuals.isApprox(expected_residual, 1e-6));
 
-    // Try numerically evaluating the Jacobians
-    std::vector<Eigen::MatrixXd> numerical_jacobians =
-        ceres_nav::computeNumericalJacobians(
-            factor, parameter_blocks, 1e-6,
-            ceres_nav::NumericalJacobianMethod::CENTRAL);
-    REQUIRE(numerical_jacobians.size() == jacobians.size());
+      // Try numerically evaluating the Jacobians
+      std::vector<Eigen::MatrixXd> numerical_jacobians =
+          ceres_nav::computeNumericalJacobians(
+              factor, parameter_blocks, 1e-6,
+              ceres_nav::NumericalJacobianMethod::CENTRAL);
+      REQUIRE(numerical_jacobians.size() == jacobians.size());
 
-    // Check the Jacobians numerically
-    std::vector<Eigen::MatrixXd> analytical_jacobians;
-    std::vector<Eigen::MatrixXd> numerical_jacs;
-    bool is_correct = ceres_nav::checkNumericalJacobians(
-        factor, parameter_blocks, analytical_jacobians, numerical_jacs,
-        ceres_nav::NumericalJacobianMethod::CENTRAL, 1e-6, false);
-    REQUIRE(is_correct);
+      // Check the Jacobians numerically
+      std::vector<Eigen::MatrixXd> analytical_jacobians;
+      std::vector<Eigen::MatrixXd> numerical_jacs;
+      bool is_correct = ceres_nav::checkNumericalJacobians(
+          factor, parameter_blocks, analytical_jacobians, numerical_jacs,
+          ceres_nav::NumericalJacobianMethod::CENTRAL, 1e-6, false);
+      REQUIRE(is_correct);
+    }
   }
 }
 
-TEST_CASE("Test RelativeLandmarkFactorJacobians") {
+TEST_CASE("RelativeLandmarkFactor") {
   Eigen::Matrix3d attitude = SO3::expMap(Eigen::Vector3d(0.5, -0.2, 0.3));
   Eigen::Vector3d position(2.0, 2.0, 3.0);
 
@@ -91,32 +103,39 @@ TEST_CASE("Test RelativeLandmarkFactorJacobians") {
 
   std::vector<LieDirection> directions = {LieDirection::left,
                                           LieDirection::right};
-  for (auto const &direction : directions) {
-    std::cout << "Testing RelativeLandmarkFactor with direction: "
-              << (direction == LieDirection::left ? "left" : "right")
-              << std::endl;
-    std::shared_ptr<RelativeLandmarkFactor> factor =
-        std::make_shared<RelativeLandmarkFactor>(meas, sqrt_info, 0.0, 1,
-                                                 direction, "SE3");
-    // Create parameter blocks to evaluate this factor at
-    std::shared_ptr<PoseParameterBlock> pose_block =
-        std::make_shared<PoseParameterBlock>("test_pose", direction);
-    pose_block->setFromAttitudeAndPosition(attitude, position);
-    std::shared_ptr<ParameterBlock<3>> landmark_block =
-        std::make_shared<ParameterBlock<3>>("landmark_1");
-    landmark_block->setEstimate(landmark_position);
 
-    std::vector<std::shared_ptr<ParameterBlockBase>> parameter_blocks;
-    parameter_blocks.push_back(pose_block);
-    parameter_blocks.push_back(landmark_block);
+  std::vector<ExtendedPoseRepresentation> pose_types = {
+      ExtendedPoseRepresentation::SE23, ExtendedPoseRepresentation::Decoupled};
 
-    // Check the Jacobians numerically
-    std::vector<Eigen::MatrixXd> analytical_jacobians;
-    std::vector<Eigen::MatrixXd> numerical_jacobians;
-    bool is_correct = ceres_nav::checkNumericalJacobians(
-        factor, parameter_blocks, analytical_jacobians, numerical_jacobians,
-        ceres_nav::NumericalJacobianMethod::CENTRAL, 1e-6, false);
-    REQUIRE(is_correct);
+  for (auto const &pose_type : pose_types) {
+    for (auto const &direction : directions) {
+      LOG(INFO) << "Testing RelativeLandmarkFactor with direction: "
+                << (direction == LieDirection::left ? "left" : "right");
+      std::shared_ptr<RelativeLandmarkFactor> factor =
+          std::make_shared<RelativeLandmarkFactor>(meas, sqrt_info, 0.0,
+                                                   direction, pose_type);
+      // Create parameter blocks to evaluate this factor at
+      std::shared_ptr<ExtendedPoseParameterBlock> pose_block =
+          std::make_shared<ExtendedPoseParameterBlock>(pose_type, "test_pose",
+                                                       direction);
+      pose_block->setFromComponents(attitude, Eigen::Vector3d::Zero(),
+                                    position);
+      std::shared_ptr<ParameterBlock<3>> landmark_block =
+          std::make_shared<ParameterBlock<3>>("landmark_1");
+      landmark_block->setEstimate(landmark_position);
+
+      std::vector<std::shared_ptr<ParameterBlockBase>> parameter_blocks;
+      parameter_blocks.push_back(pose_block);
+      parameter_blocks.push_back(landmark_block);
+
+      // Check the Jacobians numerically
+      std::vector<Eigen::MatrixXd> analytical_jacobians;
+      std::vector<Eigen::MatrixXd> numerical_jacobians;
+      bool is_correct = ceres_nav::checkNumericalJacobians(
+          factor, parameter_blocks, analytical_jacobians, numerical_jacobians,
+          ceres_nav::NumericalJacobianMethod::CENTRAL, 1e-6, false);
+      REQUIRE(is_correct);
+    }
   }
 }
 
@@ -190,17 +209,21 @@ TEST_CASE("Test Preintegration Factor") {
   Eigen::Matrix<double, 6, 1> b_j;
   b_j << 0.5, 0.6, 0.2, 0.2, 0.1, 0.4;
 
+  ExtendedPoseRepresentation rep_type = ExtendedPoseRepresentation::SE23;
+
   for (auto const &direction : directions) {
     std::cout << "Testing IMUPreintegrationFactor with direction: "
               << (direction == LieDirection::left ? "left" : "right")
               << std::endl;
     std::shared_ptr<ExtendedPoseParameterBlock> X_i_block =
-        std::make_shared<ExtendedPoseParameterBlock>(X_i, "X_i", direction);
+        std::make_shared<ExtendedPoseParameterBlock>(X_i, rep_type, "X_i",
+                                                     direction);
     std::shared_ptr<ParameterBlock<6>> b_i_block =
         std::make_shared<ParameterBlock<6>>(b_i, "b_i");
 
     std::shared_ptr<ExtendedPoseParameterBlock> X_j_block =
-        std::make_shared<ExtendedPoseParameterBlock>(X_j, "X_j", direction);
+        std::make_shared<ExtendedPoseParameterBlock>(X_j, rep_type, "X_j",
+                                                     direction);
     std::shared_ptr<ParameterBlock<6>> b_j_block =
         std::make_shared<ParameterBlock<6>>(b_j, "b_i");
 
@@ -212,7 +235,7 @@ TEST_CASE("Test Preintegration Factor") {
 
     // Create an IMU increment and propagate it forward
     IMUIncrement imu_increment(Q_ct, init_gyro_bias, init_accel_bias, 0.0,
-                               gravity, "continuous", direction);
+                               gravity, direction);
     for (int i = 0; i < num_imu_meas; ++i) {
       double dt = 0.01;
       Eigen::Vector3d omega = Eigen::Vector3d::Random();
@@ -232,12 +255,12 @@ TEST_CASE("Test Preintegration Factor") {
         factor, parameter_blocks, analytical_jacobians, numerical_jacobians,
         ceres_nav::NumericalJacobianMethod::CENTRAL, 1e-6, true);
 
-
     for (size_t i = 0; i < analytical_jacobians.size(); ++i) {
-        Eigen::MatrixXd difference =
-            analytical_jacobians[i] - numerical_jacobians[i];
-        double norm = difference.norm();
-        std::cout << "Jacobian " << i << " norm difference: " << norm  << std::endl;
+      Eigen::MatrixXd difference =
+          analytical_jacobians[i] - numerical_jacobians[i];
+      double norm = difference.norm();
+      std::cout << "Jacobian " << i << " norm difference: " << norm
+                << std::endl;
     }
     // REQUIRE(is_correct);
   }

--- a/tests/test_jacobians.cpp
+++ b/tests/test_jacobians.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Test AbsolutePositionFactor Jacobians") {
                 << std::endl;
       std::shared_ptr<AbsolutePositionFactor> factor =
           std::make_shared<AbsolutePositionFactor>(measurement, direction,
-                                                   sqrt_info, false, pose_type);
+                                                   sqrt_info, pose_type);
       REQUIRE(factor->num_residuals() == 3);
 
       // Evaluate the factor with an ExtendedPoseParameterBlock
@@ -109,8 +109,6 @@ TEST_CASE("RelativeLandmarkFactor") {
 
   for (auto const &pose_type : pose_types) {
     for (auto const &direction : directions) {
-      LOG(INFO) << "Testing RelativeLandmarkFactor with direction: "
-                << (direction == LieDirection::left ? "left" : "right");
       std::shared_ptr<RelativeLandmarkFactor> factor =
           std::make_shared<RelativeLandmarkFactor>(meas, sqrt_info, 0.0,
                                                    direction, pose_type);
@@ -139,7 +137,7 @@ TEST_CASE("RelativeLandmarkFactor") {
   }
 }
 
-TEST_CASE("Test RelativePoseFactor Jacobians") {
+TEST_CASE("RelativePoseFactor") {
   Eigen::Matrix4d T_i = SE3::expMap(Eigen::VectorXd::Random(6));
   Eigen::Matrix4d T_j = SE3::expMap(Eigen::VectorXd::Random(6));
   Eigen::Matrix4d relative_pose_meas =
@@ -180,9 +178,7 @@ TEST_CASE("Test RelativePoseFactor Jacobians") {
   }
 }
 
-TEST_CASE("Test Preintegration Factor") {
-  std::cout << "Testing preintegrated IMU factor Jacobians" << std::endl;
-
+TEST_CASE("IMUPreintegrationFactor") {
   // Create an IMU increment
   Eigen::Matrix<double, 12, 12> Q_ct =
       Eigen::Matrix<double, 12, 12>::Identity() * 0.01;
@@ -190,8 +186,6 @@ TEST_CASE("Test Preintegration Factor") {
   Eigen::Vector3d init_accel_bias{0.1, 0.2, 0.3};
   Eigen::Vector3d gravity(0.0, 0.0, -9.81);
 
-  std::vector<LieDirection> directions = {LieDirection::left,
-                                          LieDirection::right};
   int num_imu_meas = 10;
   bool use_group_jacobians = true;
 
@@ -209,59 +203,72 @@ TEST_CASE("Test Preintegration Factor") {
   Eigen::Matrix<double, 6, 1> b_j;
   b_j << 0.5, 0.6, 0.2, 0.2, 0.1, 0.4;
 
-  ExtendedPoseRepresentation rep_type = ExtendedPoseRepresentation::SE23;
+  // Pose representations to test
+  std::vector<ExtendedPoseRepresentation> rep_types =
+      {ExtendedPoseRepresentation::SE23, ExtendedPoseRepresentation::Decoupled};
 
-  for (auto const &direction : directions) {
-    std::cout << "Testing IMUPreintegrationFactor with direction: "
-              << (direction == LieDirection::left ? "left" : "right")
-              << std::endl;
-    std::shared_ptr<ExtendedPoseParameterBlock> X_i_block =
-        std::make_shared<ExtendedPoseParameterBlock>(X_i, rep_type, "X_i",
-                                                     direction);
-    std::shared_ptr<ParameterBlock<6>> b_i_block =
-        std::make_shared<ParameterBlock<6>>(b_i, "b_i");
+  std::vector<LieDirection>
+      directions = {LieDirection::left, LieDirection::right};
 
-    std::shared_ptr<ExtendedPoseParameterBlock> X_j_block =
-        std::make_shared<ExtendedPoseParameterBlock>(X_j, rep_type, "X_j",
-                                                     direction);
-    std::shared_ptr<ParameterBlock<6>> b_j_block =
-        std::make_shared<ParameterBlock<6>>(b_j, "b_i");
+  for (auto const &rep_type : rep_types) {
+    for (auto const &direction : directions) {
 
-    std::vector<std::shared_ptr<ParameterBlockBase>> parameter_blocks;
-    parameter_blocks.push_back(X_i_block);
-    parameter_blocks.push_back(b_i_block);
-    parameter_blocks.push_back(X_j_block);
-    parameter_blocks.push_back(b_j_block);
+      if (rep_type == ExtendedPoseRepresentation::Decoupled &&
+          direction == LieDirection::left) {
+        LOG(INFO) << "Left Lie direction for decoupled representation not "
+                     "supported yet. Skipping test.";
+        continue;
+      }
+      std::shared_ptr<ExtendedPoseParameterBlock> X_i_block =
+          std::make_shared<ExtendedPoseParameterBlock>(X_i, rep_type, "X_i",
+                                                       direction);
+      std::shared_ptr<ParameterBlock<6>> b_i_block =
+          std::make_shared<ParameterBlock<6>>(b_i, "b_i");
 
-    // Create an IMU increment and propagate it forward
-    IMUIncrement imu_increment(Q_ct, init_gyro_bias, init_accel_bias, 0.0,
-                               gravity, direction);
-    for (int i = 0; i < num_imu_meas; ++i) {
-      double dt = 0.01;
-      Eigen::Vector3d omega = Eigen::Vector3d::Random();
-      Eigen::Vector3d accel = Eigen::Vector3d::Random();
-      imu_increment.pushBack(dt, omega, accel);
+      std::shared_ptr<ExtendedPoseParameterBlock> X_j_block =
+          std::make_shared<ExtendedPoseParameterBlock>(X_j, rep_type, "X_j",
+                                                       direction);
+      std::shared_ptr<ParameterBlock<6>> b_j_block =
+          std::make_shared<ParameterBlock<6>>(b_j, "b_i");
+
+      std::vector<std::shared_ptr<ParameterBlockBase>> parameter_blocks;
+      parameter_blocks.push_back(X_i_block);
+      parameter_blocks.push_back(b_i_block);
+      parameter_blocks.push_back(X_j_block);
+      parameter_blocks.push_back(b_j_block);
+
+      // Create an IMU increment and propagate it forward
+      IMUIncrement imu_increment(Q_ct, init_gyro_bias, init_accel_bias, 0.0,
+                                 gravity, direction, rep_type);
+      for (int i = 0; i < num_imu_meas; ++i) {
+        double dt = 0.01;
+        Eigen::Vector3d omega = Eigen::Vector3d::Random();
+        Eigen::Vector3d accel = Eigen::Vector3d::Random();
+        imu_increment.pushBack(dt, omega, accel);
+      }
+
+      // Create the factor
+      std::shared_ptr<IMUPreintegrationFactor> factor =
+          std::make_shared<IMUPreintegrationFactor>(
+              imu_increment, use_group_jacobians, direction, rep_type);
+
+      // Evaluate the factor with the parameter blocks
+      std::vector<Eigen::MatrixXd> analytical_jacobians;
+      std::vector<Eigen::MatrixXd> numerical_jacobians;
+      bool is_correct = ceres_nav::checkNumericalJacobians(
+          factor, parameter_blocks, analytical_jacobians, numerical_jacobians,
+          ceres_nav::NumericalJacobianMethod::CENTRAL, 1e-6, false);
+
+      for (size_t i = 0; i < analytical_jacobians.size(); ++i) {
+        Eigen::MatrixXd difference =
+            analytical_jacobians[i] - numerical_jacobians[i];
+        // double norm = difference.norm();
+        // std::cout << "Jacobian " << i << " norm difference: " << norm
+        //           << std::endl;
+        // std::cout << "Jacobian " << i << std::endl;
+        // std::cout << "Difference:\n" << difference << std::endl;
+      }
+      // REQUIRE(is_correct);
     }
-
-    // Create the factor
-    std::shared_ptr<IMUPreintegrationFactor> factor =
-        std::make_shared<IMUPreintegrationFactor>(
-            imu_increment, use_group_jacobians, direction);
-
-    // Evaluate the factor with the parameter blocks
-    std::vector<Eigen::MatrixXd> analytical_jacobians;
-    std::vector<Eigen::MatrixXd> numerical_jacobians;
-    bool is_correct = ceres_nav::checkNumericalJacobians(
-        factor, parameter_blocks, analytical_jacobians, numerical_jacobians,
-        ceres_nav::NumericalJacobianMethod::CENTRAL, 1e-6, true);
-
-    for (size_t i = 0; i < analytical_jacobians.size(); ++i) {
-      Eigen::MatrixXd difference =
-          analytical_jacobians[i] - numerical_jacobians[i];
-      double norm = difference.norm();
-      std::cout << "Jacobian " << i << " norm difference: " << norm
-                << std::endl;
-    }
-    // REQUIRE(is_correct);
   }
 }

--- a/tests/test_parameter_blocks.cpp
+++ b/tests/test_parameter_blocks.cpp
@@ -97,7 +97,8 @@ TEST_CASE("Test Pose Parameter Block") {
 }
 
 TEST_CASE("Test Extended Poses") {
-  ExtendedPoseParameterBlock extended_pose_block("extended_pose_block",
+  ExtendedPoseRepresentation rep_type = ExtendedPoseRepresentation::SE23;
+  ExtendedPoseParameterBlock extended_pose_block(rep_type, "extended_pose_block",
                                                  LieDirection::left);
   REQUIRE(extended_pose_block.dimension() == 15);
   REQUIRE(extended_pose_block.minimalDimension() == 9);


### PR DESCRIPTION
Adds a decoupled state representation for extended poses, allowing a user to select between representing extended poses as elements of SE_2(3) or SO(3) x R^6.